### PR TITLE
New acceptance test which should pass with 100 % rate

### DIFF
--- a/test_cases/CompareMatkaFi.json
+++ b/test_cases/CompareMatkaFi.json
@@ -19,7 +19,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -40,7 +39,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -61,7 +59,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vieremä"
           }
         ],
         "coordinates": [
@@ -82,7 +79,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -103,7 +99,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Myrskylä"
           }
         ],
         "coordinates": [
@@ -124,7 +119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sievi"
           }
         ],
         "coordinates": [
@@ -145,7 +139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaarina"
           }
         ],
         "coordinates": [
@@ -166,7 +159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vieremä"
           }
         ],
         "coordinates": [
@@ -187,7 +179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -208,7 +199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -229,7 +219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suonenjoki"
           }
         ],
         "coordinates": [
@@ -250,7 +239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -271,7 +259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Soini"
           }
         ],
         "coordinates": [
@@ -292,7 +279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -313,7 +299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -334,7 +319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -355,7 +339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alavus"
           }
         ],
         "coordinates": [
@@ -376,7 +359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -397,7 +379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hirvensalmi"
           }
         ],
         "coordinates": [
@@ -418,7 +399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tammela"
           }
         ],
         "coordinates": [
@@ -439,7 +419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -460,7 +439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -481,7 +459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sysmä"
           }
         ],
         "coordinates": [
@@ -502,7 +479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -523,7 +499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -544,7 +519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puolanka"
           }
         ],
         "coordinates": [
@@ -565,7 +539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinlahti"
           }
         ],
         "coordinates": [
@@ -586,7 +559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ulvila"
           }
         ],
         "coordinates": [
@@ -607,7 +579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -628,7 +599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Isokyrö"
           }
         ],
         "coordinates": [
@@ -649,7 +619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Haapavesi"
           }
         ],
         "coordinates": [
@@ -670,7 +639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -691,7 +659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hyvinkää"
           }
         ],
         "coordinates": [
@@ -712,7 +679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Merikarvia"
           }
         ],
         "coordinates": [
@@ -733,7 +699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Saarijärvi"
           }
         ],
         "coordinates": [
@@ -754,7 +719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Humppila"
           }
         ],
         "coordinates": [
@@ -775,7 +739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -796,7 +759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -817,7 +779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -838,7 +799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ähtäri"
           }
         ],
         "coordinates": [
@@ -859,7 +819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joutsa"
           }
         ],
         "coordinates": [
@@ -880,7 +839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kruunupyy"
           }
         ],
         "coordinates": [
@@ -901,7 +859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tohmajärvi"
           }
         ],
         "coordinates": [
@@ -922,7 +879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhava"
           }
         ],
         "coordinates": [
@@ -943,7 +899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Liperi"
           }
         ],
         "coordinates": [
@@ -964,7 +919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -985,7 +939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikajoki"
           }
         ],
         "coordinates": [
@@ -1006,7 +959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -1027,7 +979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -1048,7 +999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -1069,7 +1019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -1090,7 +1039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -1111,7 +1059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Paltamo"
           }
         ],
         "coordinates": [
@@ -1132,7 +1079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Valtimo"
           }
         ],
         "coordinates": [
@@ -1153,7 +1099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1174,7 +1119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -1195,7 +1139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tammela"
           }
         ],
         "coordinates": [
@@ -1216,7 +1159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Heinola"
           }
         ],
         "coordinates": [
@@ -1237,7 +1179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -1258,7 +1199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -1279,7 +1219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raahe"
           }
         ],
         "coordinates": [
@@ -1300,7 +1239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -1321,7 +1259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -1342,7 +1279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pello"
           }
         ],
         "coordinates": [
@@ -1363,7 +1299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -1384,7 +1319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -1405,7 +1339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ii"
           }
         ],
         "coordinates": [
@@ -1426,7 +1359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Virolahti"
           }
         ],
         "coordinates": [
@@ -1447,7 +1379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -1468,7 +1399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Heinola"
           }
         ],
         "coordinates": [
@@ -1489,7 +1419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Merikarvia"
           }
         ],
         "coordinates": [
@@ -1510,7 +1439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kalajoki"
           }
         ],
         "coordinates": [
@@ -1531,7 +1459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sulkava"
           }
         ],
         "coordinates": [
@@ -1552,7 +1479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -1573,7 +1499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -1594,7 +1519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ypäjä"
           }
         ],
         "coordinates": [
@@ -1615,7 +1539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -1636,7 +1559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmoinen"
           }
         ],
         "coordinates": [
@@ -1657,7 +1579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Orivesi"
           }
         ],
         "coordinates": [
@@ -1678,7 +1599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -1699,7 +1619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -1720,7 +1639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kruunupyy"
           }
         ],
         "coordinates": [
@@ -1741,7 +1659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -1762,7 +1679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muhos"
           }
         ],
         "coordinates": [
@@ -1783,7 +1699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Konnevesi"
           }
         ],
         "coordinates": [
@@ -1804,7 +1719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -1825,7 +1739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kannonkoski"
           }
         ],
         "coordinates": [
@@ -1846,7 +1759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kurikka"
           }
         ],
         "coordinates": [
@@ -1867,7 +1779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Haapajärvi"
           }
         ],
         "coordinates": [
@@ -1888,7 +1799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Haapajärvi"
           }
         ],
         "coordinates": [
@@ -1909,7 +1819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hyvinkää"
           }
         ],
         "coordinates": [
@@ -1930,7 +1839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -1951,7 +1859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -1972,7 +1879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -1993,7 +1899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -2014,7 +1919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -2035,7 +1939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -2056,7 +1959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puolanka"
           }
         ],
         "coordinates": [
@@ -2077,7 +1979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -2098,7 +1999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pälkäne"
           }
         ],
         "coordinates": [
@@ -2119,7 +2019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kurikka"
           }
         ],
         "coordinates": [
@@ -2140,7 +2039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -2161,7 +2059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hyrynsalmi"
           }
         ],
         "coordinates": [
@@ -2182,7 +2079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Eura"
           }
         ],
         "coordinates": [
@@ -2203,7 +2099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -2224,7 +2119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesanto"
           }
         ],
         "coordinates": [
@@ -2245,7 +2139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -2266,7 +2159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -2287,7 +2179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -2308,7 +2199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -2329,7 +2219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -2350,7 +2239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautalampi"
           }
         ],
         "coordinates": [
@@ -2371,7 +2259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kristiinankaupunki"
           }
         ],
         "coordinates": [
@@ -2392,7 +2279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -2413,7 +2299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -2434,7 +2319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -2455,7 +2339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -2476,7 +2359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -2497,7 +2379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -2518,7 +2399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -2539,7 +2419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -2560,7 +2439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -2581,7 +2459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siilinjärvi"
           }
         ],
         "coordinates": [
@@ -2602,7 +2479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -2623,7 +2499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -2644,7 +2519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kärkölä"
           }
         ],
         "coordinates": [
@@ -2665,7 +2539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -2686,7 +2559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savitaipale"
           }
         ],
         "coordinates": [
@@ -2707,7 +2579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -2728,7 +2599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -2749,7 +2619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -2770,7 +2639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karstula"
           }
         ],
         "coordinates": [
@@ -2791,7 +2659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kihniö"
           }
         ],
         "coordinates": [
@@ -2812,7 +2679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -2833,7 +2699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -2854,7 +2719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -2875,7 +2739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -2896,7 +2759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -2917,7 +2779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -2938,7 +2799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -2959,7 +2819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -2980,7 +2839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kalajoki"
           }
         ],
         "coordinates": [
@@ -3001,7 +2859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pello"
           }
         ],
         "coordinates": [
@@ -3022,7 +2879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -3043,7 +2899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinjärvi"
           }
         ],
         "coordinates": [
@@ -3064,7 +2919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -3085,7 +2939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lappeenranta"
           }
         ],
         "coordinates": [
@@ -3106,7 +2959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -3127,7 +2979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Utsjoki"
           }
         ],
         "coordinates": [
@@ -3148,7 +2999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämijärvi"
           }
         ],
         "coordinates": [
@@ -3169,7 +3019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -3190,7 +3039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -3211,7 +3059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -3232,7 +3079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tammela"
           }
         ],
         "coordinates": [
@@ -3253,7 +3099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -3274,7 +3119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -3295,7 +3139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -3316,7 +3159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -3337,7 +3179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhajoki"
           }
         ],
         "coordinates": [
@@ -3358,7 +3199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pornainen"
           }
         ],
         "coordinates": [
@@ -3379,7 +3219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jalasjärvi"
           }
         ],
         "coordinates": [
@@ -3400,7 +3239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -3421,7 +3259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Porvoo"
           }
         ],
         "coordinates": [
@@ -3442,7 +3279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tammela"
           }
         ],
         "coordinates": [
@@ -3463,7 +3299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -3484,7 +3319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ulvila"
           }
         ],
         "coordinates": [
@@ -3505,7 +3339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -3526,7 +3359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Padasjoki"
           }
         ],
         "coordinates": [
@@ -3547,7 +3379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ii"
           }
         ],
         "coordinates": [
@@ -3568,7 +3399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Isokyrö"
           }
         ],
         "coordinates": [
@@ -3589,7 +3419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -3610,7 +3439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -3631,7 +3459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -3652,7 +3479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keminmaa"
           }
         ],
         "coordinates": [
@@ -3673,7 +3499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -3694,7 +3519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -3715,7 +3539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -3736,7 +3559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suonenjoki"
           }
         ],
         "coordinates": [
@@ -3757,7 +3579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilmajoki"
           }
         ],
         "coordinates": [
@@ -3778,7 +3599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -3799,7 +3619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesanto"
           }
         ],
         "coordinates": [
@@ -3820,7 +3639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muonio"
           }
         ],
         "coordinates": [
@@ -3841,7 +3659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sievi"
           }
         ],
         "coordinates": [
@@ -3862,7 +3679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervo"
           }
         ],
         "coordinates": [
@@ -3883,7 +3699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Saarijärvi"
           }
         ],
         "coordinates": [
@@ -3904,7 +3719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -3925,7 +3739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tammela"
           }
         ],
         "coordinates": [
@@ -3946,7 +3759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lestijärvi"
           }
         ],
         "coordinates": [
@@ -3967,7 +3779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -3988,7 +3799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -4009,7 +3819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaustinen"
           }
         ],
         "coordinates": [
@@ -4030,7 +3839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tuusniemi"
           }
         ],
         "coordinates": [
@@ -4051,7 +3859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -4072,7 +3879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jalasjärvi"
           }
         ],
         "coordinates": [
@@ -4093,7 +3899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -4114,7 +3919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Iitti"
           }
         ],
         "coordinates": [
@@ -4135,7 +3939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -4156,7 +3959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ulvila"
           }
         ],
         "coordinates": [
@@ -4177,7 +3979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alajärvi"
           }
         ],
         "coordinates": [
@@ -4198,7 +3999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -4219,7 +4019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylitornio"
           }
         ],
         "coordinates": [
@@ -4240,7 +4039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Reisjärvi"
           }
         ],
         "coordinates": [
@@ -4261,7 +4059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parikkala"
           }
         ],
         "coordinates": [
@@ -4282,7 +4079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raahe"
           }
         ],
         "coordinates": [
@@ -4303,7 +4099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -4324,7 +4119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -4345,7 +4139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -4366,7 +4159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -4387,7 +4179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rusko"
           }
         ],
         "coordinates": [
@@ -4408,7 +4199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylöjärvi"
           }
         ],
         "coordinates": [
@@ -4429,7 +4219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -4450,7 +4239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joroinen"
           }
         ],
         "coordinates": [
@@ -4471,7 +4259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hattula"
           }
         ],
         "coordinates": [
@@ -4492,7 +4279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taipalsaari"
           }
         ],
         "coordinates": [
@@ -4513,7 +4299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -4534,7 +4319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hartola"
           }
         ],
         "coordinates": [
@@ -4555,7 +4339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -4576,7 +4359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -4597,7 +4379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -4618,7 +4399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -4639,7 +4419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämijärvi"
           }
         ],
         "coordinates": [
@@ -4660,7 +4439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -4681,7 +4459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kokkola"
           }
         ],
         "coordinates": [
@@ -4702,7 +4479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -4723,7 +4499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -4744,7 +4519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -4765,7 +4539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -4786,7 +4559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -4807,7 +4579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Uusikaupunki"
           }
         ],
         "coordinates": [
@@ -4828,7 +4599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tuusniemi"
           }
         ],
         "coordinates": [
@@ -4849,7 +4619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -4870,7 +4639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -4891,7 +4659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -4912,7 +4679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -4933,7 +4699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasala"
           }
         ],
         "coordinates": [
@@ -4954,7 +4719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -4975,7 +4739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -4996,7 +4759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vöyri"
           }
         ],
         "coordinates": [
@@ -5017,7 +4779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylivieska"
           }
         ],
         "coordinates": [
@@ -5038,7 +4799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -5059,7 +4819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -5080,7 +4839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muhos"
           }
         ],
         "coordinates": [
@@ -5101,7 +4859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -5122,7 +4879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuortane"
           }
         ],
         "coordinates": [
@@ -5143,7 +4899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -5164,7 +4919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -5185,7 +4939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaarina"
           }
         ],
         "coordinates": [
@@ -5206,7 +4959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -5227,7 +4979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -5248,7 +4999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -5269,7 +5019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -5290,7 +5039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -5311,7 +5059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -5332,7 +5079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -5353,7 +5099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -5374,7 +5119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sysmä"
           }
         ],
         "coordinates": [
@@ -5395,7 +5139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joutsa"
           }
         ],
         "coordinates": [
@@ -5416,7 +5159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Porvoo"
           }
         ],
         "coordinates": [
@@ -5437,7 +5179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -5458,7 +5199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Utajärvi"
           }
         ],
         "coordinates": [
@@ -5479,7 +5219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -5500,7 +5239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taipalsaari"
           }
         ],
         "coordinates": [
@@ -5521,7 +5259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -5542,7 +5279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -5563,7 +5299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karstula"
           }
         ],
         "coordinates": [
@@ -5584,7 +5319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -5605,7 +5339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alavieska"
           }
         ],
         "coordinates": [
@@ -5626,7 +5359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -5647,7 +5379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -5668,7 +5399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -5689,7 +5419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -5710,7 +5439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hamina"
           }
         ],
         "coordinates": [
@@ -5731,7 +5459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -5752,7 +5479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -5773,7 +5499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -5794,7 +5519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -5815,7 +5539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -5836,7 +5559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keminmaa"
           }
         ],
         "coordinates": [
@@ -5857,7 +5579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -5878,7 +5599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siuntio"
           }
         ],
         "coordinates": [
@@ -5899,7 +5619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Honkajoki"
           }
         ],
         "coordinates": [
@@ -5920,7 +5639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loviisa"
           }
         ],
         "coordinates": [
@@ -5941,7 +5659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -5962,7 +5679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Urjala"
           }
         ],
         "coordinates": [
@@ -5983,7 +5699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinlahti"
           }
         ],
         "coordinates": [
@@ -6004,7 +5719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sauvo"
           }
         ],
         "coordinates": [
@@ -6025,7 +5739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inkoo"
           }
         ],
         "coordinates": [
@@ -6046,7 +5759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -6067,7 +5779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Virrat"
           }
         ],
         "coordinates": [
@@ -6088,7 +5799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -6109,7 +5819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -6130,7 +5839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Perho"
           }
         ],
         "coordinates": [
@@ -6151,7 +5859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karstula"
           }
         ],
         "coordinates": [
@@ -6172,7 +5879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Enontekiö"
           }
         ],
         "coordinates": [
@@ -6193,7 +5899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -6214,7 +5919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pedersören kunta"
           }
         ],
         "coordinates": [
@@ -6235,7 +5939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -6256,7 +5959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -6277,7 +5979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Eura"
           }
         ],
         "coordinates": [
@@ -6298,7 +5999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -6319,7 +6019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -6340,7 +6039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikajoki"
           }
         ],
         "coordinates": [
@@ -6361,7 +6059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Paltamo"
           }
         ],
         "coordinates": [
@@ -6382,7 +6079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -6403,7 +6099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tyrnävä"
           }
         ],
         "coordinates": [
@@ -6424,7 +6119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -6445,7 +6139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -6466,7 +6159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vieremä"
           }
         ],
         "coordinates": [
@@ -6487,7 +6179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -6508,7 +6199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -6529,7 +6219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -6550,7 +6239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loppi"
           }
         ],
         "coordinates": [
@@ -6571,7 +6259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -6592,7 +6279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -6613,7 +6299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -6634,7 +6319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Paltamo"
           }
         ],
         "coordinates": [
@@ -6655,7 +6339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hattula"
           }
         ],
         "coordinates": [
@@ -6676,7 +6359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -6697,7 +6379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kurikka"
           }
         ],
         "coordinates": [
@@ -6718,7 +6399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylivieska"
           }
         ],
         "coordinates": [
@@ -6739,7 +6419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karvia"
           }
         ],
         "coordinates": [
@@ -6760,7 +6439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lappeenranta"
           }
         ],
         "coordinates": [
@@ -6781,7 +6459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -6802,7 +6479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -6823,7 +6499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -6844,7 +6519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -6865,7 +6539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -6886,7 +6559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhajoki"
           }
         ],
         "coordinates": [
@@ -6907,7 +6579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -6928,7 +6599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juankoski"
           }
         ],
         "coordinates": [
@@ -6949,7 +6619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -6970,7 +6639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -6991,7 +6659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -7012,7 +6679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muonio"
           }
         ],
         "coordinates": [
@@ -7033,7 +6699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Askola"
           }
         ],
         "coordinates": [
@@ -7054,7 +6719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -7075,7 +6739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -7096,7 +6759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taivalkoski"
           }
         ],
         "coordinates": [
@@ -7117,7 +6779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -7138,7 +6799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Naantali"
           }
         ],
         "coordinates": [
@@ -7159,7 +6819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -7180,7 +6839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -7201,7 +6859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinlahti"
           }
         ],
         "coordinates": [
@@ -7222,7 +6879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikajoki"
           }
         ],
         "coordinates": [
@@ -7243,7 +6899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Toivakka"
           }
         ],
         "coordinates": [
@@ -7264,7 +6919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juankoski"
           }
         ],
         "coordinates": [
@@ -7285,7 +6939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mustasaari"
           }
         ],
         "coordinates": [
@@ -7306,7 +6959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -7327,7 +6979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -7348,7 +6999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kannonkoski"
           }
         ],
         "coordinates": [
@@ -7369,7 +7019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieto"
           }
         ],
         "coordinates": [
@@ -7390,7 +7039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pälkäne"
           }
         ],
         "coordinates": [
@@ -7411,7 +7059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaarina"
           }
         ],
         "coordinates": [
@@ -7432,7 +7079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -7453,7 +7099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -7474,7 +7119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Urjala"
           }
         ],
         "coordinates": [
@@ -7495,7 +7139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapua"
           }
         ],
         "coordinates": [
@@ -7516,7 +7159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -7537,7 +7179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kivijärvi"
           }
         ],
         "coordinates": [
@@ -7558,7 +7199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Eurajoki"
           }
         ],
         "coordinates": [
@@ -7579,7 +7219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -7600,7 +7239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Urjala"
           }
         ],
         "coordinates": [
@@ -7621,7 +7259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaavi"
           }
         ],
         "coordinates": [
@@ -7642,7 +7279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -7663,7 +7299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -7684,7 +7319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ähtäri"
           }
         ],
         "coordinates": [
@@ -7705,7 +7339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Halsua"
           }
         ],
         "coordinates": [
@@ -7726,7 +7359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -7747,7 +7379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Haapajärvi"
           }
         ],
         "coordinates": [
@@ -7768,7 +7399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -7789,7 +7419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -7810,7 +7439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Iitti"
           }
         ],
         "coordinates": [
@@ -7831,7 +7459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siuntio"
           }
         ],
         "coordinates": [
@@ -7852,7 +7479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -7873,7 +7499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -7894,7 +7519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -7915,7 +7539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikajoki"
           }
         ],
         "coordinates": [
@@ -7936,7 +7559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Virolahti"
           }
         ],
         "coordinates": [
@@ -7957,7 +7579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -7978,7 +7599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Multia"
           }
         ],
         "coordinates": [
@@ -7999,7 +7619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -8020,7 +7639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -8041,7 +7659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -8062,7 +7679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Viitasaari"
           }
         ],
         "coordinates": [
@@ -8083,7 +7699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raasepori"
           }
         ],
         "coordinates": [
@@ -8104,7 +7719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -8125,7 +7739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hollola"
           }
         ],
         "coordinates": [
@@ -8146,7 +7759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tornio"
           }
         ],
         "coordinates": [
@@ -8167,7 +7779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keminmaa"
           }
         ],
         "coordinates": [
@@ -8188,7 +7799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -8209,7 +7819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karstula"
           }
         ],
         "coordinates": [
@@ -8230,7 +7839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -8251,7 +7859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -8272,7 +7879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sulkava"
           }
         ],
         "coordinates": [
@@ -8293,7 +7899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ristijärvi"
           }
         ],
         "coordinates": [
@@ -8314,7 +7919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Urjala"
           }
         ],
         "coordinates": [
@@ -8335,7 +7939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -8356,7 +7959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Utajärvi"
           }
         ],
         "coordinates": [
@@ -8377,7 +7979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Halsua"
           }
         ],
         "coordinates": [
@@ -8398,7 +7999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hyrynsalmi"
           }
         ],
         "coordinates": [
@@ -8419,7 +8019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -8440,7 +8039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -8461,7 +8059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laihia"
           }
         ],
         "coordinates": [
@@ -8482,7 +8079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -8503,7 +8099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -8524,7 +8119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -8545,7 +8139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Viitasaari"
           }
         ],
         "coordinates": [
@@ -8566,7 +8159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -8587,7 +8179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämijärvi"
           }
         ],
         "coordinates": [
@@ -8608,7 +8199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -8629,7 +8219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -8650,7 +8239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Valtimo"
           }
         ],
         "coordinates": [
@@ -8671,7 +8259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -8692,7 +8279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -8713,7 +8299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siuntio"
           }
         ],
         "coordinates": [
@@ -8734,7 +8319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -8755,7 +8339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -8776,7 +8359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -8797,7 +8379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hamina"
           }
         ],
         "coordinates": [
@@ -8818,7 +8399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -8839,7 +8419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -8860,7 +8439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -8881,7 +8459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salo"
           }
         ],
         "coordinates": [
@@ -8902,7 +8479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -8923,7 +8499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sievi"
           }
         ],
         "coordinates": [
@@ -8944,7 +8519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juuka"
           }
         ],
         "coordinates": [
@@ -8965,7 +8539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -8986,7 +8559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -9007,7 +8579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenkoski"
           }
         ],
         "coordinates": [
@@ -9028,7 +8599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loviisa"
           }
         ],
         "coordinates": [
@@ -9049,7 +8619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lappeenranta"
           }
         ],
         "coordinates": [
@@ -9070,7 +8639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -9091,7 +8659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -9112,7 +8679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulainen"
           }
         ],
         "coordinates": [
@@ -9133,7 +8699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -9154,7 +8719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pomarkku"
           }
         ],
         "coordinates": [
@@ -9175,7 +8739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alajärvi"
           }
         ],
         "coordinates": [
@@ -9196,7 +8759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -9217,7 +8779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -9238,7 +8799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Virolahti"
           }
         ],
         "coordinates": [
@@ -9259,7 +8819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Janakkala"
           }
         ],
         "coordinates": [
@@ -9280,7 +8839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -9301,7 +8859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -9322,7 +8879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Heinola"
           }
         ],
         "coordinates": [
@@ -9343,7 +8899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -9364,7 +8919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -9385,7 +8939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Aura"
           }
         ],
         "coordinates": [
@@ -9406,7 +8959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -9427,7 +8979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -9448,7 +8999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -9469,7 +9019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Teuva"
           }
         ],
         "coordinates": [
@@ -9490,7 +9039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -9511,7 +9059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -9532,7 +9079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keminmaa"
           }
         ],
         "coordinates": [
@@ -9553,7 +9099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Paltamo"
           }
         ],
         "coordinates": [
@@ -9574,7 +9119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kruunupyy"
           }
         ],
         "coordinates": [
@@ -9595,7 +9139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kajaani"
           }
         ],
         "coordinates": [
@@ -9616,7 +9159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -9637,7 +9179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -9658,7 +9199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Viitasaari"
           }
         ],
         "coordinates": [
@@ -9679,7 +9219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautjärvi"
           }
         ],
         "coordinates": [
@@ -9700,7 +9239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -9721,7 +9259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tohmajärvi"
           }
         ],
         "coordinates": [
@@ -9742,7 +9279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -9763,7 +9299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -9784,7 +9319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -9805,7 +9339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alavieska"
           }
         ],
         "coordinates": [
@@ -9826,7 +9359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Konnevesi"
           }
         ],
         "coordinates": [
@@ -9847,7 +9379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -9868,7 +9399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -9889,7 +9419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -9910,7 +9439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -9931,7 +9459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joroinen"
           }
         ],
         "coordinates": [
@@ -9952,7 +9479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -9973,7 +9499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sievi"
           }
         ],
         "coordinates": [
@@ -9994,7 +9519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -10015,7 +9539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -10036,7 +9559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikainen"
           }
         ],
         "coordinates": [
@@ -10057,7 +9579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Outokumpu"
           }
         ],
         "coordinates": [
@@ -10078,7 +9599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -10099,7 +9619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -10120,7 +9639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikainen"
           }
         ],
         "coordinates": [
@@ -10141,7 +9659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -10162,7 +9679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Uurainen"
           }
         ],
         "coordinates": [
@@ -10183,7 +9699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -10204,7 +9719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -10225,7 +9739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -10246,7 +9759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -10267,7 +9779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautalampi"
           }
         ],
         "coordinates": [
@@ -10288,7 +9799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alajärvi"
           }
         ],
         "coordinates": [
@@ -10309,7 +9819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -10330,7 +9839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasala"
           }
         ],
         "coordinates": [
@@ -10351,7 +9859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesanto"
           }
         ],
         "coordinates": [
@@ -10372,7 +9879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -10393,7 +9899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -10414,7 +9919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -10435,7 +9939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rauma"
           }
         ],
         "coordinates": [
@@ -10456,7 +9959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -10477,7 +9979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaavi"
           }
         ],
         "coordinates": [
@@ -10498,7 +9999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -10519,7 +10019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -10540,7 +10039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -10561,7 +10059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inkoo"
           }
         ],
         "coordinates": [
@@ -10582,7 +10079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -10603,7 +10099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhava"
           }
         ],
         "coordinates": [
@@ -10624,7 +10119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -10645,7 +10139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -10666,7 +10159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suonenjoki"
           }
         ],
         "coordinates": [
@@ -10687,7 +10179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -10708,7 +10199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -10729,7 +10219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Luvia"
           }
         ],
         "coordinates": [
@@ -10750,7 +10239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -10771,7 +10259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -10792,7 +10279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -10813,7 +10299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -10834,7 +10319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Heinävesi"
           }
         ],
         "coordinates": [
@@ -10855,7 +10339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sysmä"
           }
         ],
         "coordinates": [
@@ -10876,7 +10359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raasepori"
           }
         ],
         "coordinates": [
@@ -10897,7 +10379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -10918,7 +10399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -10939,7 +10419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -10960,7 +10439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -10981,7 +10459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -11002,7 +10479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -11023,7 +10499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -11044,7 +10519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Leppävirta"
           }
         ],
         "coordinates": [
@@ -11065,7 +10539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ähtäri"
           }
         ],
         "coordinates": [
@@ -11086,7 +10559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -11107,7 +10579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hyrynsalmi"
           }
         ],
         "coordinates": [
@@ -11128,7 +10599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -11149,7 +10619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Toholampi"
           }
         ],
         "coordinates": [
@@ -11170,7 +10639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raahe"
           }
         ],
         "coordinates": [
@@ -11191,7 +10659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ypäjä"
           }
         ],
         "coordinates": [
@@ -11212,7 +10679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loimaa"
           }
         ],
         "coordinates": [
@@ -11233,7 +10699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Isokyrö"
           }
         ],
         "coordinates": [
@@ -11254,7 +10719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -11275,7 +10739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -11296,7 +10759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -11317,7 +10779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -11338,7 +10799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -11359,7 +10819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parainen"
           }
         ],
         "coordinates": [
@@ -11380,7 +10839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -11401,7 +10859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -11422,7 +10879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -11443,7 +10899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hanko"
           }
         ],
         "coordinates": [
@@ -11464,7 +10919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -11485,7 +10939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -11506,7 +10959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karstula"
           }
         ],
         "coordinates": [
@@ -11527,7 +10979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -11548,7 +10999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -11569,7 +11019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -11590,7 +11039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Uusikaarlepyy"
           }
         ],
         "coordinates": [
@@ -11611,7 +11059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pietarsaari"
           }
         ],
         "coordinates": [
@@ -11632,7 +11079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Multia"
           }
         ],
         "coordinates": [
@@ -11653,7 +11099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hartola"
           }
         ],
         "coordinates": [
@@ -11674,7 +11119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mustasaari"
           }
         ],
         "coordinates": [
@@ -11695,7 +11139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -11716,7 +11159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -11737,7 +11179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -11758,7 +11199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -11779,7 +11219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kruunupyy"
           }
         ],
         "coordinates": [
@@ -11800,7 +11239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -11821,7 +11259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parainen"
           }
         ],
         "coordinates": [
@@ -11842,7 +11279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Naantali"
           }
         ],
         "coordinates": [
@@ -11863,7 +11299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -11884,7 +11319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -11905,7 +11339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -11926,7 +11359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juankoski"
           }
         ],
         "coordinates": [
@@ -11947,7 +11379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Akaa"
           }
         ],
         "coordinates": [
@@ -11968,7 +11399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kokkola"
           }
         ],
         "coordinates": [
@@ -11989,7 +11419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -12010,7 +11439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -12031,7 +11459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -12052,7 +11479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laukaa"
           }
         ],
         "coordinates": [
@@ -12073,7 +11499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -12094,7 +11519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -12115,7 +11539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juuka"
           }
         ],
         "coordinates": [
@@ -12136,7 +11559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Toivakka"
           }
         ],
         "coordinates": [
@@ -12157,7 +11579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -12178,7 +11599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -12199,7 +11619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kannus"
           }
         ],
         "coordinates": [
@@ -12220,7 +11639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mynämäki"
           }
         ],
         "coordinates": [
@@ -12241,7 +11659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemiönsaari"
           }
         ],
         "coordinates": [
@@ -12262,7 +11679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -12283,7 +11699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesanto"
           }
         ],
         "coordinates": [
@@ -12304,7 +11719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tampere"
           }
         ],
         "coordinates": [
@@ -12325,7 +11739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -12346,7 +11759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pertunmaa"
           }
         ],
         "coordinates": [
@@ -12367,7 +11779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -12388,7 +11799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Leppävirta"
           }
         ],
         "coordinates": [
@@ -12409,7 +11819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kristiinankaupunki"
           }
         ],
         "coordinates": [
@@ -12430,7 +11839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -12451,7 +11859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Virrat"
           }
         ],
         "coordinates": [
@@ -12472,7 +11879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -12493,7 +11899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Porvoo"
           }
         ],
         "coordinates": [
@@ -12514,7 +11919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -12535,7 +11939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -12556,7 +11959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -12577,7 +11979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sievi"
           }
         ],
         "coordinates": [
@@ -12598,7 +11999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -12619,7 +12019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salo"
           }
         ],
         "coordinates": [
@@ -12640,7 +12039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -12661,7 +12059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kivijärvi"
           }
         ],
         "coordinates": [
@@ -12682,7 +12079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -12703,7 +12099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siilinjärvi"
           }
         ],
         "coordinates": [
@@ -12724,7 +12119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kokemäki"
           }
         ],
         "coordinates": [
@@ -12745,7 +12139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -12766,7 +12159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -12787,7 +12179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -12808,7 +12199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -12829,7 +12219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kittilä"
           }
         ],
         "coordinates": [
@@ -12850,7 +12239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hartola"
           }
         ],
         "coordinates": [
@@ -12871,7 +12259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -12892,7 +12279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -12913,7 +12299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -12934,7 +12319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juuka"
           }
         ],
         "coordinates": [
@@ -12955,7 +12339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmijärvi"
           }
         ],
         "coordinates": [
@@ -12976,7 +12359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jalasjärvi"
           }
         ],
         "coordinates": [
@@ -12997,7 +12379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -13018,7 +12399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vimpeli"
           }
         ],
         "coordinates": [
@@ -13039,7 +12419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -13060,7 +12439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhajoki"
           }
         ],
         "coordinates": [
@@ -13081,7 +12459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäranta"
           }
         ],
         "coordinates": [
@@ -13102,7 +12479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Heinävesi"
           }
         ],
         "coordinates": [
@@ -13123,7 +12499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -13144,7 +12519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -13165,7 +12539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raahe"
           }
         ],
         "coordinates": [
@@ -13186,7 +12559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raasepori"
           }
         ],
         "coordinates": [
@@ -13207,7 +12579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -13228,7 +12599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -13249,7 +12619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautavaara"
           }
         ],
         "coordinates": [
@@ -13270,7 +12639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Orimattila"
           }
         ],
         "coordinates": [
@@ -13291,7 +12659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -13312,7 +12679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -13333,7 +12699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -13354,7 +12719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -13375,7 +12739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -13396,7 +12759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -13417,7 +12779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -13438,7 +12799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Perho"
           }
         ],
         "coordinates": [
@@ -13459,7 +12819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaarina"
           }
         ],
         "coordinates": [
@@ -13480,7 +12839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -13501,7 +12859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -13522,7 +12879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -13543,7 +12899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjoki"
           }
         ],
         "coordinates": [
@@ -13564,7 +12919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hirvensalmi"
           }
         ],
         "coordinates": [
@@ -13585,7 +12939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Marttila"
           }
         ],
         "coordinates": [
@@ -13606,7 +12959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -13627,7 +12979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Eura"
           }
         ],
         "coordinates": [
@@ -13648,7 +12999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -13669,7 +13019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savitaipale"
           }
         ],
         "coordinates": [
@@ -13690,7 +13039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -13711,7 +13059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -13732,7 +13079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -13753,7 +13099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -13774,7 +13119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -13795,7 +13139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylitornio"
           }
         ],
         "coordinates": [
@@ -13816,7 +13159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -13837,7 +13179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muhos"
           }
         ],
         "coordinates": [
@@ -13858,7 +13199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -13879,7 +13219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -13900,7 +13239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ähtäri"
           }
         ],
         "coordinates": [
@@ -13921,7 +13259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -13942,7 +13279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -13963,7 +13299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -13984,7 +13319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pihtipudas"
           }
         ],
         "coordinates": [
@@ -14005,7 +13339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemiönsaari"
           }
         ],
         "coordinates": [
@@ -14026,7 +13359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -14047,7 +13379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -14068,7 +13399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -14089,7 +13419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenkoski"
           }
         ],
         "coordinates": [
@@ -14110,7 +13439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Köyliö"
           }
         ],
         "coordinates": [
@@ -14131,7 +13459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -14152,7 +13479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -14173,7 +13499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -14194,7 +13519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Haapavesi"
           }
         ],
         "coordinates": [
@@ -14215,7 +13539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karvia"
           }
         ],
         "coordinates": [
@@ -14236,7 +13559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylitornio"
           }
         ],
         "coordinates": [
@@ -14257,7 +13579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inkoo"
           }
         ],
         "coordinates": [
@@ -14278,7 +13599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauhajoki"
           }
         ],
         "coordinates": [
@@ -14299,7 +13619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -14320,7 +13639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Orivesi"
           }
         ],
         "coordinates": [
@@ -14341,7 +13659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -14362,7 +13679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -14383,7 +13699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -14404,7 +13719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -14425,7 +13739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapua"
           }
         ],
         "coordinates": [
@@ -14446,7 +13759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -14467,7 +13779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joutsa"
           }
         ],
         "coordinates": [
@@ -14488,7 +13799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jyväskylä"
           }
         ],
         "coordinates": [
@@ -14509,7 +13819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -14530,7 +13839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Köyliö"
           }
         ],
         "coordinates": [
@@ -14551,7 +13859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Liperi"
           }
         ],
         "coordinates": [
@@ -14572,7 +13879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -14593,7 +13899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -14614,7 +13919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -14635,7 +13939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Huittinen"
           }
         ],
         "coordinates": [
@@ -14656,7 +13959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -14677,7 +13979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Miehikkälä"
           }
         ],
         "coordinates": [
@@ -14698,7 +13999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -14719,7 +14019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lestijärvi"
           }
         ],
         "coordinates": [
@@ -14740,7 +14039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kannus"
           }
         ],
         "coordinates": [
@@ -14761,7 +14059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Myrskylä"
           }
         ],
         "coordinates": [
@@ -14782,7 +14079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -14803,7 +14099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loviisa"
           }
         ],
         "coordinates": [
@@ -14824,7 +14119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kyyjärvi"
           }
         ],
         "coordinates": [
@@ -14845,7 +14139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kontiolahti"
           }
         ],
         "coordinates": [
@@ -14866,7 +14159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -14887,7 +14179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -14908,7 +14199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Merikarvia"
           }
         ],
         "coordinates": [
@@ -14929,7 +14219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -14950,7 +14239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -14971,7 +14259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -14992,7 +14279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Jämsä"
           }
         ],
         "coordinates": [
@@ -15013,7 +14299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Enontekiö"
           }
         ],
         "coordinates": [
@@ -15034,7 +14319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -15055,7 +14339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hailuoto"
           }
         ],
         "coordinates": [
@@ -15076,7 +14359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Toivakka"
           }
         ],
         "coordinates": [
@@ -15097,7 +14379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -15118,7 +14399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjoki"
           }
         ],
         "coordinates": [
@@ -15139,7 +14419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -15160,7 +14439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Somero"
           }
         ],
         "coordinates": [
@@ -15181,7 +14459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -15202,7 +14479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Reisjärvi"
           }
         ],
         "coordinates": [
@@ -15223,7 +14499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parikkala"
           }
         ],
         "coordinates": [
@@ -15244,7 +14519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kruunupyy"
           }
         ],
         "coordinates": [
@@ -15265,7 +14539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hartola"
           }
         ],
         "coordinates": [
@@ -15286,7 +14559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -15307,7 +14579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kurikka"
           }
         ],
         "coordinates": [
@@ -15328,7 +14599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kankaanpää"
           }
         ],
         "coordinates": [
@@ -15349,7 +14619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervo"
           }
         ],
         "coordinates": [
@@ -15370,7 +14639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -15391,7 +14659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -15412,7 +14679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -15433,7 +14699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kankaanpää"
           }
         ],
         "coordinates": [
@@ -15454,7 +14719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taivalkoski"
           }
         ],
         "coordinates": [
@@ -15475,7 +14739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -15496,7 +14759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Iitti"
           }
         ],
         "coordinates": [
@@ -15517,7 +14779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pieksämäki"
           }
         ],
         "coordinates": [
@@ -15538,7 +14799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Petäjävesi"
           }
         ],
         "coordinates": [
@@ -15559,7 +14819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasala"
           }
         ],
         "coordinates": [
@@ -15580,7 +14839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rantasalmi"
           }
         ],
         "coordinates": [
@@ -15601,7 +14859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Miehikkälä"
           }
         ],
         "coordinates": [
@@ -15622,7 +14879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -15643,7 +14899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -15664,7 +14919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salo"
           }
         ],
         "coordinates": [
@@ -15685,7 +14939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Polvijärvi"
           }
         ],
         "coordinates": [
@@ -15706,7 +14959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -15727,7 +14979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Köyliö"
           }
         ],
         "coordinates": [
@@ -15748,7 +14999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Konnevesi"
           }
         ],
         "coordinates": [
@@ -15769,7 +15019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -15790,7 +15039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -15811,7 +15059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -15832,7 +15079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -15853,7 +15099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -15874,7 +15119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karvia"
           }
         ],
         "coordinates": [
@@ -15895,7 +15139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juva"
           }
         ],
         "coordinates": [
@@ -15916,7 +15159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautalampi"
           }
         ],
         "coordinates": [
@@ -15937,7 +15179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kinnula"
           }
         ],
         "coordinates": [
@@ -15958,7 +15199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kustavi"
           }
         ],
         "coordinates": [
@@ -15979,7 +15219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmijärvi"
           }
         ],
         "coordinates": [
@@ -16000,7 +15239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hollola"
           }
         ],
         "coordinates": [
@@ -16021,7 +15259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -16042,7 +15279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylöjärvi"
           }
         ],
         "coordinates": [
@@ -16063,7 +15299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesilahti"
           }
         ],
         "coordinates": [
@@ -16084,7 +15319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Simo"
           }
         ],
         "coordinates": [
@@ -16105,7 +15339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ii"
           }
         ],
         "coordinates": [
@@ -16126,7 +15359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -16147,7 +15379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -16168,7 +15399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -16189,7 +15419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -16210,7 +15439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pälkäne"
           }
         ],
         "coordinates": [
@@ -16231,7 +15459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Posio"
           }
         ],
         "coordinates": [
@@ -16252,7 +15479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -16273,7 +15499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tohmajärvi"
           }
         ],
         "coordinates": [
@@ -16294,7 +15519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -16315,7 +15539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muonio"
           }
         ],
         "coordinates": [
@@ -16336,7 +15559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rääkkylä"
           }
         ],
         "coordinates": [
@@ -16357,7 +15579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -16378,7 +15599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hamina"
           }
         ],
         "coordinates": [
@@ -16399,7 +15619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Miehikkälä"
           }
         ],
         "coordinates": [
@@ -16420,7 +15639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -16441,7 +15659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tohmajärvi"
           }
         ],
         "coordinates": [
@@ -16462,7 +15679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäntä"
           }
         ],
         "coordinates": [
@@ -16483,7 +15699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -16504,7 +15719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suonenjoki"
           }
         ],
         "coordinates": [
@@ -16525,7 +15739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -16546,7 +15759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -16567,7 +15779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parainen"
           }
         ],
         "coordinates": [
@@ -16588,7 +15799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -16609,7 +15819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -16630,7 +15839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suonenjoki"
           }
         ],
         "coordinates": [
@@ -16651,7 +15859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -16672,7 +15879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vesanto"
           }
         ],
         "coordinates": [
@@ -16693,7 +15899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Miehikkälä"
           }
         ],
         "coordinates": [
@@ -16714,7 +15919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kiuruvesi"
           }
         ],
         "coordinates": [
@@ -16735,7 +15939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilmajoki"
           }
         ],
         "coordinates": [
@@ -16756,7 +15959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Padasjoki"
           }
         ],
         "coordinates": [
@@ -16777,7 +15979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -16798,7 +15999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parainen"
           }
         ],
         "coordinates": [
@@ -16819,7 +16019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hausjärvi"
           }
         ],
         "coordinates": [
@@ -16840,7 +16039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -16861,7 +16059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemiönsaari"
           }
         ],
         "coordinates": [
@@ -16882,7 +16079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -16903,7 +16099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laukaa"
           }
         ],
         "coordinates": [
@@ -16924,7 +16119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -16945,7 +16139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taivalkoski"
           }
         ],
         "coordinates": [
@@ -16966,7 +16159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -16987,7 +16179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pello"
           }
         ],
         "coordinates": [
@@ -17008,7 +16199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Seinäjoki"
           }
         ],
         "coordinates": [
@@ -17029,7 +16219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ii"
           }
         ],
         "coordinates": [
@@ -17050,7 +16239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kitee"
           }
         ],
         "coordinates": [
@@ -17071,7 +16259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -17092,7 +16279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -17113,7 +16299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Viitasaari"
           }
         ],
         "coordinates": [
@@ -17134,7 +16319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kajaani"
           }
         ],
         "coordinates": [
@@ -17155,7 +16339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Enontekiö"
           }
         ],
         "coordinates": [
@@ -17176,7 +16359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -17197,7 +16379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joroinen"
           }
         ],
         "coordinates": [
@@ -17218,7 +16399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Viitasaari"
           }
         ],
         "coordinates": [
@@ -17239,7 +16419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikalatva"
           }
         ],
         "coordinates": [
@@ -17260,7 +16439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -17281,7 +16459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -17302,7 +16479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Myrskylä"
           }
         ],
         "coordinates": [
@@ -17323,7 +16499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raasepori"
           }
         ],
         "coordinates": [
@@ -17344,7 +16519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Huittinen"
           }
         ],
         "coordinates": [
@@ -17365,7 +16539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laukaa"
           }
         ],
         "coordinates": [
@@ -17386,7 +16559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juankoski"
           }
         ],
         "coordinates": [
@@ -17407,7 +16579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -17428,7 +16599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kurikka"
           }
         ],
         "coordinates": [
@@ -17449,7 +16619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -17470,7 +16639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Iisalmi"
           }
         ],
         "coordinates": [
@@ -17491,7 +16659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -17512,7 +16679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -17533,7 +16699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kannonkoski"
           }
         ],
         "coordinates": [
@@ -17554,7 +16719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -17575,7 +16739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -17596,7 +16759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lestijärvi"
           }
         ],
         "coordinates": [
@@ -17617,7 +16779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -17638,7 +16799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kaavi"
           }
         ],
         "coordinates": [
@@ -17659,7 +16819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Orivesi"
           }
         ],
         "coordinates": [
@@ -17680,7 +16839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -17701,7 +16859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Padasjoki"
           }
         ],
         "coordinates": [
@@ -17722,7 +16879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -17743,7 +16899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinlahti"
           }
         ],
         "coordinates": [
@@ -17764,7 +16919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -17785,7 +16939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kolari"
           }
         ],
         "coordinates": [
@@ -17806,7 +16959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -17827,7 +16979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -17848,7 +16999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Enontekiö"
           }
         ],
         "coordinates": [
@@ -17869,7 +17019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -17890,7 +17039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tornio"
           }
         ],
         "coordinates": [
@@ -17911,7 +17059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylöjärvi"
           }
         ],
         "coordinates": [
@@ -17932,7 +17079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raasepori"
           }
         ],
         "coordinates": [
@@ -17953,7 +17099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -17974,7 +17119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mustasaari"
           }
         ],
         "coordinates": [
@@ -17995,7 +17139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kokkola"
           }
         ],
         "coordinates": [
@@ -18016,7 +17159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puumala"
           }
         ],
         "coordinates": [
@@ -18037,7 +17179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautavaara"
           }
         ],
         "coordinates": [
@@ -18058,7 +17199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keitele"
           }
         ],
         "coordinates": [
@@ -18079,7 +17219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmijärvi"
           }
         ],
         "coordinates": [
@@ -18100,7 +17239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Leppävirta"
           }
         ],
         "coordinates": [
@@ -18121,7 +17259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikainen"
           }
         ],
         "coordinates": [
@@ -18142,7 +17279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -18163,7 +17299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Enontekiö"
           }
         ],
         "coordinates": [
@@ -18184,7 +17319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Alavus"
           }
         ],
         "coordinates": [
@@ -18205,7 +17339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -18226,7 +17359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -18247,7 +17379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -18268,7 +17399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vaala"
           }
         ],
         "coordinates": [
@@ -18289,7 +17419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ähtäri"
           }
         ],
         "coordinates": [
@@ -18310,7 +17439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Humppila"
           }
         ],
         "coordinates": [
@@ -18331,7 +17459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuopio"
           }
         ],
         "coordinates": [
@@ -18352,7 +17479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -18373,7 +17499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laukaa"
           }
         ],
         "coordinates": [
@@ -18394,7 +17519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -18415,7 +17539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Miehikkälä"
           }
         ],
         "coordinates": [
@@ -18436,7 +17559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ikaalinen"
           }
         ],
         "coordinates": [
@@ -18457,7 +17579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rantasalmi"
           }
         ],
         "coordinates": [
@@ -18478,7 +17599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taipalsaari"
           }
         ],
         "coordinates": [
@@ -18499,7 +17619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Valkeakoski"
           }
         ],
         "coordinates": [
@@ -18520,7 +17639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ranua"
           }
         ],
         "coordinates": [
@@ -18541,7 +17659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puolanka"
           }
         ],
         "coordinates": [
@@ -18562,7 +17679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Siikainen"
           }
         ],
         "coordinates": [
@@ -18583,7 +17699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tohmajärvi"
           }
         ],
         "coordinates": [
@@ -18604,7 +17719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joutsa"
           }
         ],
         "coordinates": [
@@ -18625,7 +17739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -18646,7 +17759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Puolanka"
           }
         ],
         "coordinates": [
@@ -18667,7 +17779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Akaa"
           }
         ],
         "coordinates": [
@@ -18688,7 +17799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lohja"
           }
         ],
         "coordinates": [
@@ -18709,7 +17819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lapinlahti"
           }
         ],
         "coordinates": [
@@ -18730,7 +17839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -18751,7 +17859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -18772,7 +17879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -18793,7 +17899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tornio"
           }
         ],
         "coordinates": [
@@ -18814,7 +17919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -18835,7 +17939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -18856,7 +17959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruokolahti"
           }
         ],
         "coordinates": [
@@ -18877,7 +17979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pielavesi"
           }
         ],
         "coordinates": [
@@ -18898,7 +17999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juuka"
           }
         ],
         "coordinates": [
@@ -18919,7 +18019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -18940,7 +18039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -18961,7 +18059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -18982,7 +18079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sastamala"
           }
         ],
         "coordinates": [
@@ -19003,7 +18099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -19024,7 +18119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pelkosenniemi"
           }
         ],
         "coordinates": [
@@ -19045,7 +18139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Karkkila"
           }
         ],
         "coordinates": [
@@ -19066,7 +18159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sonkajärvi"
           }
         ],
         "coordinates": [
@@ -19087,7 +18179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuhmo"
           }
         ],
         "coordinates": [
@@ -19108,7 +18199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Orivesi"
           }
         ],
         "coordinates": [
@@ -19129,7 +18219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ylitornio"
           }
         ],
         "coordinates": [
@@ -19150,7 +18239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -19171,7 +18259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kivijärvi"
           }
         ],
         "coordinates": [
@@ -19192,7 +18279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Asikkala"
           }
         ],
         "coordinates": [
@@ -19213,7 +18299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -19234,7 +18319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -19255,7 +18339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pori"
           }
         ],
         "coordinates": [
@@ -19276,7 +18359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juva"
           }
         ],
         "coordinates": [
@@ -19297,7 +18379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Urjala"
           }
         ],
         "coordinates": [
@@ -19318,7 +18399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -19339,7 +18419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Liminka"
           }
         ],
         "coordinates": [
@@ -19360,7 +18439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tuusniemi"
           }
         ],
         "coordinates": [
@@ -19381,7 +18459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -19402,7 +18479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Muhos"
           }
         ],
         "coordinates": [
@@ -19423,7 +18499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hankasalmi"
           }
         ],
         "coordinates": [
@@ -19444,7 +18519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Parikkala"
           }
         ],
         "coordinates": [
@@ -19465,7 +18539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -19486,7 +18559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Inari"
           }
         ],
         "coordinates": [
@@ -19507,7 +18579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nousiainen"
           }
         ],
         "coordinates": [
@@ -19528,7 +18599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Reisjärvi"
           }
         ],
         "coordinates": [
@@ -19549,7 +18619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -19570,7 +18639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Uusikaupunki"
           }
         ],
         "coordinates": [
@@ -19591,7 +18659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -19612,7 +18679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Raahe"
           }
         ],
         "coordinates": [
@@ -19633,7 +18699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Perho"
           }
         ],
         "coordinates": [
@@ -19654,7 +18719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juankoski"
           }
         ],
         "coordinates": [
@@ -19675,7 +18739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ruovesi"
           }
         ],
         "coordinates": [
@@ -19696,7 +18759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savonlinna"
           }
         ],
         "coordinates": [
@@ -19717,7 +18779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -19738,7 +18799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautavaara"
           }
         ],
         "coordinates": [
@@ -19759,7 +18819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hollola"
           }
         ],
         "coordinates": [
@@ -19780,7 +18839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nivala"
           }
         ],
         "coordinates": [
@@ -19801,7 +18859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kouvola"
           }
         ],
         "coordinates": [
@@ -19822,7 +18879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salla"
           }
         ],
         "coordinates": [
@@ -19843,7 +18899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Paltamo"
           }
         ],
         "coordinates": [
@@ -19864,7 +18919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Salo"
           }
         ],
         "coordinates": [
@@ -19885,7 +18939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Taivalkoski"
           }
         ],
         "coordinates": [
@@ -19906,7 +18959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautavaara"
           }
         ],
         "coordinates": [
@@ -19927,7 +18979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -19948,7 +18999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -19969,7 +19019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kajaani"
           }
         ],
         "coordinates": [
@@ -19990,7 +19039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pyhäjärvi"
           }
         ],
         "coordinates": [
@@ -20011,7 +19059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Lieksa"
           }
         ],
         "coordinates": [
@@ -20032,7 +19079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sauvo"
           }
         ],
         "coordinates": [
@@ -20053,7 +19099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -20074,7 +19119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tervola"
           }
         ],
         "coordinates": [
@@ -20095,7 +19139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sodankylä"
           }
         ],
         "coordinates": [
@@ -20116,7 +19159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Valtimo"
           }
         ],
         "coordinates": [
@@ -20137,7 +19179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -20158,7 +19199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Keuruu"
           }
         ],
         "coordinates": [
@@ -20179,7 +19219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sotkamo"
           }
         ],
         "coordinates": [
@@ -20200,7 +19239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pälkäne"
           }
         ],
         "coordinates": [
@@ -20221,7 +19259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Perho"
           }
         ],
         "coordinates": [
@@ -20242,7 +19279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Laukaa"
           }
         ],
         "coordinates": [
@@ -20263,7 +19299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Porvoo"
           }
         ],
         "coordinates": [
@@ -20284,7 +19319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pöytyä"
           }
         ],
         "coordinates": [
@@ -20305,7 +19339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Nurmes"
           }
         ],
         "coordinates": [
@@ -20326,7 +19359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [
@@ -20347,7 +19379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tuusniemi"
           }
         ],
         "coordinates": [
@@ -20368,7 +19399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kangasniemi"
           }
         ],
         "coordinates": [
@@ -20389,7 +19419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Äänekoski"
           }
         ],
         "coordinates": [
@@ -20410,7 +19439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Tornio"
           }
         ],
         "coordinates": [
@@ -20431,7 +19459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -20452,7 +19479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Savukoski"
           }
         ],
         "coordinates": [
@@ -20473,7 +19499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Utajärvi"
           }
         ],
         "coordinates": [
@@ -20494,7 +19519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Liperi"
           }
         ],
         "coordinates": [
@@ -20515,7 +19539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Hämeenlinna"
           }
         ],
         "coordinates": [
@@ -20536,7 +19559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Utsjoki"
           }
         ],
         "coordinates": [
@@ -20557,7 +19579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rautalampi"
           }
         ],
         "coordinates": [
@@ -20578,7 +19599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Oulu"
           }
         ],
         "coordinates": [
@@ -20599,7 +19619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mikkeli"
           }
         ],
         "coordinates": [
@@ -20620,7 +19639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Isojoki"
           }
         ],
         "coordinates": [
@@ -20641,7 +19659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -20662,7 +19679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Joensuu"
           }
         ],
         "coordinates": [
@@ -20683,7 +19699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -20704,7 +19719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ilomantsi"
           }
         ],
         "coordinates": [
@@ -20725,7 +19739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kemijärvi"
           }
         ],
         "coordinates": [
@@ -20746,7 +19759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Ii"
           }
         ],
         "coordinates": [
@@ -20767,7 +19779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Juva"
           }
         ],
         "coordinates": [
@@ -20788,7 +19799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Loppi"
           }
         ],
         "coordinates": [
@@ -20809,7 +19819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rääkkylä"
           }
         ],
         "coordinates": [
@@ -20830,7 +19839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Säkylä"
           }
         ],
         "coordinates": [
@@ -20851,7 +19859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Rovaniemi"
           }
         ],
         "coordinates": [
@@ -20872,7 +19879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Mäntyharju"
           }
         ],
         "coordinates": [
@@ -20893,7 +19899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Teuva"
           }
         ],
         "coordinates": [
@@ -20914,7 +19919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sysmä"
           }
         ],
         "coordinates": [
@@ -20935,7 +19939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Suomussalmi"
           }
         ],
         "coordinates": [
@@ -20956,7 +19959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Punkalaidun"
           }
         ],
         "coordinates": [
@@ -20977,7 +19979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kuusamo"
           }
         ],
         "coordinates": [
@@ -20998,7 +19999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Pudasjärvi"
           }
         ],
         "coordinates": [

--- a/test_cases/CompareOldReittiopas.json
+++ b/test_cases/CompareOldReittiopas.json
@@ -19,7 +19,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -38,7 +37,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -57,7 +55,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -76,7 +73,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -95,7 +91,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -114,7 +109,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -133,7 +127,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -152,7 +145,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -171,7 +163,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -190,7 +181,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -209,7 +199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -228,7 +217,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -247,7 +235,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -266,7 +253,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -285,7 +271,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -304,7 +289,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -323,7 +307,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -342,7 +325,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -361,7 +343,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -380,7 +361,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -399,7 +379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -418,7 +397,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -437,7 +415,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -456,7 +433,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -475,7 +451,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -494,7 +469,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -513,7 +487,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -532,7 +505,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -551,7 +523,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -570,7 +541,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -589,7 +559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -608,7 +577,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -627,7 +595,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -646,7 +613,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -665,7 +631,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -684,7 +649,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -703,7 +667,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -722,7 +685,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -741,7 +703,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -760,7 +721,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -779,7 +739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -798,7 +757,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -817,7 +775,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -836,7 +793,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -855,7 +811,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -874,7 +829,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -893,7 +847,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -912,7 +865,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -931,7 +883,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -950,7 +901,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -969,7 +919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -988,7 +937,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1007,7 +955,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1026,7 +973,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -1045,7 +991,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -1064,7 +1009,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1083,7 +1027,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1102,7 +1045,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1121,7 +1063,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1140,7 +1081,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1159,7 +1099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1178,7 +1117,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1197,7 +1135,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -1216,7 +1153,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1235,7 +1171,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1254,7 +1189,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1273,7 +1207,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1292,7 +1225,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -1311,7 +1243,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1330,7 +1261,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1349,7 +1279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1368,7 +1297,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1387,7 +1315,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -1406,7 +1333,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -1425,7 +1351,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1444,7 +1369,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1463,7 +1387,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1482,7 +1405,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -1501,7 +1423,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1520,7 +1441,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1539,7 +1459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1558,7 +1477,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -1577,7 +1495,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1596,7 +1513,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1615,7 +1531,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1634,7 +1549,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1653,7 +1567,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1672,7 +1585,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -1691,7 +1603,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1710,7 +1621,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1729,7 +1639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1748,7 +1657,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1767,7 +1675,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1786,7 +1693,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1805,7 +1711,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1824,7 +1729,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1843,7 +1747,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1862,7 +1765,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1881,7 +1783,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1900,7 +1801,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1919,7 +1819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1938,7 +1837,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1957,7 +1855,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1976,7 +1873,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1995,7 +1891,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -2014,7 +1909,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2033,7 +1927,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2052,7 +1945,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2071,7 +1963,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2090,7 +1981,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2109,7 +1999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2128,7 +2017,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2147,7 +2035,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2166,7 +2053,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2185,7 +2071,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2204,7 +2089,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2223,7 +2107,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2242,7 +2125,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2261,7 +2143,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2280,7 +2161,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2299,7 +2179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2318,7 +2197,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -2337,7 +2215,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2356,7 +2233,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2375,7 +2251,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -2394,7 +2269,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -2413,7 +2287,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2432,7 +2305,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -2451,7 +2323,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2470,7 +2341,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2489,7 +2359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2508,7 +2377,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2527,7 +2395,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2546,7 +2413,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2565,7 +2431,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -2584,7 +2449,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2603,7 +2467,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2622,7 +2485,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -2641,7 +2503,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2660,7 +2521,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2679,7 +2539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2698,7 +2557,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2717,7 +2575,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2736,7 +2593,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2755,7 +2611,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2774,7 +2629,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2793,7 +2647,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2812,7 +2665,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2831,7 +2683,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2850,7 +2701,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2869,7 +2719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2888,7 +2737,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2907,7 +2755,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2926,7 +2773,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2945,7 +2791,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2964,7 +2809,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2983,7 +2827,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3002,7 +2845,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3021,7 +2863,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3040,7 +2881,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3059,7 +2899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3078,7 +2917,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3097,7 +2935,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3116,7 +2953,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3135,7 +2971,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3154,7 +2989,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3173,7 +3007,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3192,7 +3025,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3211,7 +3043,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -3230,7 +3061,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3249,7 +3079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3268,7 +3097,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3287,7 +3115,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3306,7 +3133,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3325,7 +3151,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3344,7 +3169,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3363,7 +3187,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3382,7 +3205,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3401,7 +3223,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3420,7 +3241,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3439,7 +3259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -3458,7 +3277,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3477,7 +3295,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -3496,7 +3313,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -3515,7 +3331,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3534,7 +3349,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3553,7 +3367,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3572,7 +3385,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -3591,7 +3403,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3610,7 +3421,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3629,7 +3439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3648,7 +3457,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3667,7 +3475,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3686,7 +3493,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3705,7 +3511,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3724,7 +3529,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3743,7 +3547,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3762,7 +3565,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -3781,7 +3583,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3800,7 +3601,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3819,7 +3619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3838,7 +3637,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3857,7 +3655,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3876,7 +3673,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3895,7 +3691,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3914,7 +3709,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3933,7 +3727,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3952,7 +3745,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -3971,7 +3763,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3990,7 +3781,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4009,7 +3799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4028,7 +3817,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4047,7 +3835,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4066,7 +3853,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4085,7 +3871,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4104,7 +3889,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4123,7 +3907,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4142,7 +3925,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4161,7 +3943,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4180,7 +3961,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4199,7 +3979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4218,7 +3997,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4237,7 +4015,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4256,7 +4033,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4275,7 +4051,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4294,7 +4069,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4313,7 +4087,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4332,7 +4105,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4351,7 +4123,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4370,7 +4141,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4389,7 +4159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -4408,7 +4177,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4427,7 +4195,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4446,7 +4213,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4465,7 +4231,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4484,7 +4249,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4503,7 +4267,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4522,7 +4285,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4541,7 +4303,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4560,7 +4321,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4579,7 +4339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4598,7 +4357,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4617,7 +4375,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4636,7 +4393,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4655,7 +4411,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4674,7 +4429,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4693,7 +4447,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4712,7 +4465,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4731,7 +4483,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4750,7 +4501,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4769,7 +4519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4788,7 +4537,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4807,7 +4555,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4826,7 +4573,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4845,7 +4591,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4864,7 +4609,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4883,7 +4627,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4902,7 +4645,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4921,7 +4663,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -4940,7 +4681,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4959,7 +4699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4978,7 +4717,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4997,7 +4735,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5016,7 +4753,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5035,7 +4771,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -5054,7 +4789,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5073,7 +4807,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5092,7 +4825,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5111,7 +4843,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5130,7 +4861,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5149,7 +4879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5168,7 +4897,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5187,7 +4915,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5206,7 +4933,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5225,7 +4951,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5244,7 +4969,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5263,7 +4987,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5282,7 +5005,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5301,7 +5023,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5320,7 +5041,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5339,7 +5059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5358,7 +5077,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -5377,7 +5095,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5396,7 +5113,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5415,7 +5131,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -5434,7 +5149,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5453,7 +5167,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5472,7 +5185,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5491,7 +5203,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5510,7 +5221,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5529,7 +5239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5548,7 +5257,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -5567,7 +5275,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5586,7 +5293,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5605,7 +5311,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5624,7 +5329,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5643,7 +5347,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -5662,7 +5365,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5681,7 +5383,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5700,7 +5401,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5719,7 +5419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5738,7 +5437,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5757,7 +5455,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5776,7 +5473,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5795,7 +5491,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5814,7 +5509,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5833,7 +5527,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5852,7 +5545,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -5871,7 +5563,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5890,7 +5581,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5909,7 +5599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5928,7 +5617,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -5947,7 +5635,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5966,7 +5653,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5985,7 +5671,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6004,7 +5689,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6023,7 +5707,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6042,7 +5725,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6061,7 +5743,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6080,7 +5761,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6099,7 +5779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6118,7 +5797,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6137,7 +5815,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -6156,7 +5833,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6175,7 +5851,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6194,7 +5869,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6213,7 +5887,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6232,7 +5905,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -6251,7 +5923,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6270,7 +5941,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -6289,7 +5959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6308,7 +5977,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6327,7 +5995,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6346,7 +6013,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6365,7 +6031,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6384,7 +6049,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -6403,7 +6067,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6422,7 +6085,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6441,7 +6103,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6460,7 +6121,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -6479,7 +6139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6498,7 +6157,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6517,7 +6175,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6536,7 +6193,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6555,7 +6211,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6574,7 +6229,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6593,7 +6247,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6612,7 +6265,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -6631,7 +6283,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6650,7 +6301,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6669,7 +6319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6688,7 +6337,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6707,7 +6355,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6726,7 +6373,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6745,7 +6391,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6764,7 +6409,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6783,7 +6427,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6802,7 +6445,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6821,7 +6463,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6840,7 +6481,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -6859,7 +6499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6878,7 +6517,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6897,7 +6535,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6916,7 +6553,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6935,7 +6571,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6954,7 +6589,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6973,7 +6607,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6992,7 +6625,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -7011,7 +6643,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -7030,7 +6661,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7049,7 +6679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7068,7 +6697,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7087,7 +6715,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -7106,7 +6733,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -7125,7 +6751,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7144,7 +6769,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7163,7 +6787,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7182,7 +6805,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7201,7 +6823,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7220,7 +6841,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -7239,7 +6859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7258,7 +6877,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7277,7 +6895,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7296,7 +6913,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7315,7 +6931,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7334,7 +6949,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7353,7 +6967,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7372,7 +6985,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7391,7 +7003,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7410,7 +7021,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7429,7 +7039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7448,7 +7057,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7467,7 +7075,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7486,7 +7093,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7505,7 +7111,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7524,7 +7129,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7543,7 +7147,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -7562,7 +7165,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7581,7 +7183,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7600,7 +7201,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7619,7 +7219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7638,7 +7237,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7657,7 +7255,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7676,7 +7273,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7695,7 +7291,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7714,7 +7309,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7733,7 +7327,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7752,7 +7345,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7771,7 +7363,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -7790,7 +7381,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7809,7 +7399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7828,7 +7417,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -7847,7 +7435,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7866,7 +7453,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7885,7 +7471,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7904,7 +7489,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7923,7 +7507,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7942,7 +7525,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7961,7 +7543,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -7980,7 +7561,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -7999,7 +7579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8018,7 +7597,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8037,7 +7615,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -8056,7 +7633,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8075,7 +7651,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8094,7 +7669,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -8113,7 +7687,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8132,7 +7705,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8151,7 +7723,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8170,7 +7741,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8189,7 +7759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -8208,7 +7777,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8227,7 +7795,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8246,7 +7813,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -8265,7 +7831,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -8284,7 +7849,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8303,7 +7867,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8322,7 +7885,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8341,7 +7903,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8360,7 +7921,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8379,7 +7939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8398,7 +7957,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8417,7 +7975,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8436,7 +7993,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8455,7 +8011,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8474,7 +8029,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8493,7 +8047,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8512,7 +8065,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8531,7 +8083,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8550,7 +8101,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8569,7 +8119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8588,7 +8137,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -8607,7 +8155,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8626,7 +8173,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8645,7 +8191,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8664,7 +8209,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8683,7 +8227,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8702,7 +8245,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8721,7 +8263,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8740,7 +8281,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -8759,7 +8299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8778,7 +8317,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8797,7 +8335,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -8816,7 +8353,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8835,7 +8371,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8854,7 +8389,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8873,7 +8407,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8892,7 +8425,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8911,7 +8443,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8930,7 +8461,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8949,7 +8479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8968,7 +8497,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8987,7 +8515,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9006,7 +8533,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9025,7 +8551,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9044,7 +8569,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9063,7 +8587,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9082,7 +8605,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9101,7 +8623,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9120,7 +8641,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9139,7 +8659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9158,7 +8677,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9177,7 +8695,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9196,7 +8713,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9215,7 +8731,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9234,7 +8749,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9253,7 +8767,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -9272,7 +8785,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9291,7 +8803,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -9310,7 +8821,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9329,7 +8839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9348,7 +8857,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9367,7 +8875,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9386,7 +8893,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9405,7 +8911,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9424,7 +8929,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9443,7 +8947,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9462,7 +8965,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9481,7 +8983,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9500,7 +9001,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9519,7 +9019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9538,7 +9037,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9557,7 +9055,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9576,7 +9073,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9595,7 +9091,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9614,7 +9109,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9633,7 +9127,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9652,7 +9145,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9671,7 +9163,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9690,7 +9181,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9709,7 +9199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9728,7 +9217,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9747,7 +9235,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9766,7 +9253,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9785,7 +9271,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9804,7 +9289,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9823,7 +9307,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9842,7 +9325,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9861,7 +9343,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9880,7 +9361,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9899,7 +9379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9918,7 +9397,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9937,7 +9415,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -9956,7 +9433,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -9975,7 +9451,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9994,7 +9469,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10013,7 +9487,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10032,7 +9505,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10051,7 +9523,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10070,7 +9541,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10089,7 +9559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10108,7 +9577,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10127,7 +9595,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10146,7 +9613,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10165,7 +9631,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -10184,7 +9649,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10203,7 +9667,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10222,7 +9685,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10241,7 +9703,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10260,7 +9721,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10279,7 +9739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10298,7 +9757,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10317,7 +9775,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10336,7 +9793,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10355,7 +9811,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10374,7 +9829,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10393,7 +9847,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -10412,7 +9865,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -10431,7 +9883,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10450,7 +9901,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10469,7 +9919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10488,7 +9937,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10507,7 +9955,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10526,7 +9973,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -10545,7 +9991,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10564,7 +10009,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10583,7 +10027,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10602,7 +10045,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10621,7 +10063,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10640,7 +10081,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10659,7 +10099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10678,7 +10117,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10697,7 +10135,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10716,7 +10153,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10735,7 +10171,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10754,7 +10189,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10773,7 +10207,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10792,7 +10225,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10811,7 +10243,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -10830,7 +10261,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -10849,7 +10279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10868,7 +10297,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10887,7 +10315,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10906,7 +10333,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10925,7 +10351,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10944,7 +10369,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -10963,7 +10387,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -10982,7 +10405,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11001,7 +10423,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11020,7 +10441,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -11039,7 +10459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11058,7 +10477,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11077,7 +10495,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11096,7 +10513,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11115,7 +10531,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11134,7 +10549,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11153,7 +10567,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -11172,7 +10585,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11191,7 +10603,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11210,7 +10621,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11229,7 +10639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11248,7 +10657,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11267,7 +10675,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -11286,7 +10693,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11305,7 +10711,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11324,7 +10729,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11343,7 +10747,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -11362,7 +10765,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11381,7 +10783,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11400,7 +10801,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11419,7 +10819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11438,7 +10837,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11457,7 +10855,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11476,7 +10873,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11495,7 +10891,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11514,7 +10909,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11533,7 +10927,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11552,7 +10945,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11571,7 +10963,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11590,7 +10981,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11609,7 +10999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11628,7 +11017,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11647,7 +11035,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11666,7 +11053,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11685,7 +11071,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11704,7 +11089,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11723,7 +11107,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11742,7 +11125,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11761,7 +11143,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11780,7 +11161,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11799,7 +11179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -11818,7 +11197,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11837,7 +11215,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11856,7 +11233,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11875,7 +11251,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11894,7 +11269,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -11913,7 +11287,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11932,7 +11305,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -11951,7 +11323,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11970,7 +11341,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -11989,7 +11359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12008,7 +11377,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12027,7 +11395,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12046,7 +11413,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12065,7 +11431,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12084,7 +11449,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12103,7 +11467,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12122,7 +11485,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12141,7 +11503,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12160,7 +11521,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12179,7 +11539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12198,7 +11557,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12217,7 +11575,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12236,7 +11593,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -12255,7 +11611,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12274,7 +11629,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12293,7 +11647,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12312,7 +11665,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12331,7 +11683,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12350,7 +11701,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12369,7 +11719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12388,7 +11737,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12407,7 +11755,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12426,7 +11773,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12445,7 +11791,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -12464,7 +11809,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12483,7 +11827,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -12502,7 +11845,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -12521,7 +11863,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12540,7 +11881,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12559,7 +11899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -12578,7 +11917,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12597,7 +11935,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12616,7 +11953,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12635,7 +11971,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12654,7 +11989,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -12673,7 +12007,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12692,7 +12025,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12711,7 +12043,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12730,7 +12061,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12749,7 +12079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12768,7 +12097,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -12787,7 +12115,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12806,7 +12133,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12825,7 +12151,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12844,7 +12169,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12863,7 +12187,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12882,7 +12205,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12901,7 +12223,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12920,7 +12241,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12939,7 +12259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12958,7 +12277,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12977,7 +12295,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12996,7 +12313,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13015,7 +12331,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13034,7 +12349,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -13053,7 +12367,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13072,7 +12385,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13091,7 +12403,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13110,7 +12421,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -13129,7 +12439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13148,7 +12457,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13167,7 +12475,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13186,7 +12493,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13205,7 +12511,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13224,7 +12529,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13243,7 +12547,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13262,7 +12565,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -13281,7 +12583,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13300,7 +12601,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13319,7 +12619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13338,7 +12637,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13357,7 +12655,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13376,7 +12673,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13395,7 +12691,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -13414,7 +12709,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13433,7 +12727,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13452,7 +12745,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13471,7 +12763,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13490,7 +12781,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13509,7 +12799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13528,7 +12817,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13547,7 +12835,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13566,7 +12853,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13585,7 +12871,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13604,7 +12889,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13623,7 +12907,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13642,7 +12925,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13661,7 +12943,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13680,7 +12961,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13699,7 +12979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13718,7 +12997,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13737,7 +13015,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13756,7 +13033,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13775,7 +13051,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13794,7 +13069,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13813,7 +13087,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13832,7 +13105,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13851,7 +13123,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13870,7 +13141,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13889,7 +13159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13908,7 +13177,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13927,7 +13195,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13946,7 +13213,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13965,7 +13231,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13984,7 +13249,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14003,7 +13267,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14022,7 +13285,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14041,7 +13303,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14060,7 +13321,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14079,7 +13339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14098,7 +13357,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -14117,7 +13375,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -14136,7 +13393,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14155,7 +13411,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14174,7 +13429,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14193,7 +13447,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14212,7 +13465,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14231,7 +13483,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14250,7 +13501,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -14269,7 +13519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14288,7 +13537,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14307,7 +13555,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14326,7 +13573,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -14345,7 +13591,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14364,7 +13609,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14383,7 +13627,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14402,7 +13645,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -14421,7 +13663,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14440,7 +13681,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14459,7 +13699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14478,7 +13717,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14497,7 +13735,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14516,7 +13753,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14535,7 +13771,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14554,7 +13789,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14573,7 +13807,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14592,7 +13825,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14611,7 +13843,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14630,7 +13861,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14649,7 +13879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14668,7 +13897,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14687,7 +13915,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14706,7 +13933,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14725,7 +13951,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14744,7 +13969,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14763,7 +13987,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14782,7 +14005,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14801,7 +14023,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14820,7 +14041,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14839,7 +14059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14858,7 +14077,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14877,7 +14095,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14896,7 +14113,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14915,7 +14131,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14934,7 +14149,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14953,7 +14167,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -14972,7 +14185,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14991,7 +14203,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15010,7 +14221,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15029,7 +14239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -15048,7 +14257,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15067,7 +14275,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -15086,7 +14293,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15105,7 +14311,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15124,7 +14329,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15143,7 +14347,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15162,7 +14365,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15181,7 +14383,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15200,7 +14401,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15219,7 +14419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -15238,7 +14437,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15257,7 +14455,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15276,7 +14473,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15295,7 +14491,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15314,7 +14509,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15333,7 +14527,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15352,7 +14545,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15371,7 +14563,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15390,7 +14581,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15409,7 +14599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15428,7 +14617,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15447,7 +14635,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15466,7 +14653,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15485,7 +14671,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15504,7 +14689,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15523,7 +14707,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15542,7 +14725,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -15561,7 +14743,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15580,7 +14761,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15599,7 +14779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15618,7 +14797,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15637,7 +14815,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15656,7 +14833,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15675,7 +14851,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15694,7 +14869,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15713,7 +14887,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15732,7 +14905,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15751,7 +14923,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15770,7 +14941,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -15789,7 +14959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15808,7 +14977,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15827,7 +14995,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15846,7 +15013,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15865,7 +15031,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15884,7 +15049,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15903,7 +15067,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15922,7 +15085,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15941,7 +15103,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15960,7 +15121,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -15979,7 +15139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15998,7 +15157,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16017,7 +15175,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16036,7 +15193,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16055,7 +15211,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -16074,7 +15229,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16093,7 +15247,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16112,7 +15265,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16131,7 +15283,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16150,7 +15301,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16169,7 +15319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16188,7 +15337,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16207,7 +15355,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16226,7 +15373,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16245,7 +15391,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16264,7 +15409,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16283,7 +15427,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16302,7 +15445,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -16321,7 +15463,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16340,7 +15481,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16359,7 +15499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16378,7 +15517,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -16397,7 +15535,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16416,7 +15553,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16435,7 +15571,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -16454,7 +15589,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16473,7 +15607,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16492,7 +15625,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -16511,7 +15643,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16530,7 +15661,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16549,7 +15679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16568,7 +15697,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -16587,7 +15715,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16606,7 +15733,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16625,7 +15751,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16644,7 +15769,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16663,7 +15787,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16682,7 +15805,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16701,7 +15823,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16720,7 +15841,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16739,7 +15859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16758,7 +15877,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -16777,7 +15895,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16796,7 +15913,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16815,7 +15931,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16834,7 +15949,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -16853,7 +15967,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16872,7 +15985,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16891,7 +16003,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -16910,7 +16021,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16929,7 +16039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -16948,7 +16057,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16967,7 +16075,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16986,7 +16093,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17005,7 +16111,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17024,7 +16129,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17043,7 +16147,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17062,7 +16165,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17081,7 +16183,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17100,7 +16201,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17119,7 +16219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17138,7 +16237,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17157,7 +16255,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17176,7 +16273,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17195,7 +16291,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17214,7 +16309,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17233,7 +16327,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17252,7 +16345,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17271,7 +16363,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17290,7 +16381,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17309,7 +16399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -17328,7 +16417,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17347,7 +16435,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17366,7 +16453,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17385,7 +16471,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17404,7 +16489,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17423,7 +16507,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17442,7 +16525,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -17461,7 +16543,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17480,7 +16561,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -17499,7 +16579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -17518,7 +16597,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17537,7 +16615,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17556,7 +16633,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -17575,7 +16651,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17594,7 +16669,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -17613,7 +16687,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17632,7 +16705,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17651,7 +16723,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17670,7 +16741,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17689,7 +16759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17708,7 +16777,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17727,7 +16795,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17746,7 +16813,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -17765,7 +16831,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17784,7 +16849,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17803,7 +16867,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17822,7 +16885,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17841,7 +16903,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17860,7 +16921,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17879,7 +16939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17898,7 +16957,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17917,7 +16975,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17936,7 +16993,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -17955,7 +17011,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -17974,7 +17029,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -17993,7 +17047,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -18012,7 +17065,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18031,7 +17083,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18050,7 +17101,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18069,7 +17119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18088,7 +17137,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18107,7 +17155,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18126,7 +17173,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18145,7 +17191,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18164,7 +17209,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18183,7 +17227,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18202,7 +17245,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18221,7 +17263,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18240,7 +17281,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18259,7 +17299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18278,7 +17317,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18297,7 +17335,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18316,7 +17353,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -18335,7 +17371,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18354,7 +17389,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -18373,7 +17407,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18392,7 +17425,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18411,7 +17443,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18430,7 +17461,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18449,7 +17479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18468,7 +17497,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18487,7 +17515,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18506,7 +17533,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18525,7 +17551,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18544,7 +17569,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18563,7 +17587,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18582,7 +17605,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18601,7 +17623,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18620,7 +17641,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18639,7 +17659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18658,7 +17677,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18677,7 +17695,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18696,7 +17713,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18715,7 +17731,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18734,7 +17749,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18753,7 +17767,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18772,7 +17785,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18791,7 +17803,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18810,7 +17821,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18829,7 +17839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18848,7 +17857,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -18867,7 +17875,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18886,7 +17893,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -18905,7 +17911,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18924,7 +17929,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18943,7 +17947,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -18962,7 +17965,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -18981,7 +17983,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19000,7 +18001,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [

--- a/test_cases/HSLTop500.json
+++ b/test_cases/HSLTop500.json
@@ -9799,6 +9799,104 @@
           ]
         ]
       }
+    },
+    {
+      "id": 479,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Central railway station, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Central railway station",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941008656398",
+          "60.171245203365"
+        ]
+      }
+    },
+    {
+      "id": 480,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Airport, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Airport",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 481,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinki-Vantaa airport"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinki-Vantaa airport"
+          }
+        ],
+        "coordinates": [
+          "24.968176616303",
+          "60.318758015899"
+        ]
+      }
+    },
+    {
+      "id": 482,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautatientori metro station, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941127348533",
+          "60.170355734682"
+        ]
+      }
+    },
+    {
+      "id": 483,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "City center, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941319",
+          "60.168813"
+        ]
+      }
     }
   ]
 }

--- a/test_cases/HSLTop500.json
+++ b/test_cases/HSLTop500.json
@@ -1,0 +1,9804 @@
+{
+  "name": "reittiopas top 500 test",
+  "description": "Test if most frequent reittiopas searches can be found",
+  "priorityThresh": 3,
+  "distanceThresh": 300,
+  "normalizers": {
+    "name": [
+      "toUpperCase"
+    ]
+  },
+  "tests": [
+    {
+      "id": 0,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Aleksanterin teatteri, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.933654751383",
+          "60.163497029837"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Talkoorinne 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Talkoorinne 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.687978037438",
+          "60.202796210732"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Thalian aukio, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.895703347764",
+          "60.225647932124"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hotel Sello, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.8143666386",
+          "60.218075645416"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Yliopistonkatu 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Yliopistonkatu 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.948450201191",
+          "60.170034274094"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kamppi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kamppi",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.931335951125",
+          "60.16875533351"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lassila, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lassila",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Nuijamiestentie 10, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Nuijamiestentie 10",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.90672174046",
+          "60.218194928664"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rörstrandinkatu 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rörstrandinkatu 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.977835934309",
+          "60.20592248085"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lönnrotsgatan 13, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lönnrotsgatan 13",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          "24.936188906916",
+          "60.165839853207"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Revontulenkuja 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Revontulenkuja 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.803420928925",
+          "60.171055168497"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vironkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vironkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.958060863402",
+          "60.172191237152"
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kunnalliskodintie 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kunnalliskodintie 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.966288860901",
+          "60.216796229855"
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölöntullinkatu 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölöntullinkatu 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.912657554505",
+          "60.190274967952"
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kulorastaantie 1, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kulorastaantie 1",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.058425082817",
+          "60.345581744184"
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Käenkuja 3a, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Käenkuja 3a",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.964191672109",
+          "60.185287724118"
+        ]
+      }
+    },
+    {
+      "id": 16,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Topeliuksenkatu 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Topeliuksenkatu 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.921532153852",
+          "60.18083371358"
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viikinkaari 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viikinkaari 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.016935549096",
+          "60.226336351948"
+        ]
+      }
+    },
+    {
+      "id": 18,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jumbo, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jumbo",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.96442698332",
+          "60.291004922645"
+        ]
+      }
+    },
+    {
+      "id": 19,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Fleminginkatu 34, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Fleminginkatu 34",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951438455347",
+          "60.190523079339"
+        ]
+      }
+    },
+    {
+      "id": 20,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jämeräntaival 11, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jämeräntaival 11",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.83940738965",
+          "60.189825222642"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kallion lukio, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kallion lukio",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.954994279834",
+          "60.18385527208"
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pasteurinkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pasteurinkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.012864097898",
+          "60.224805649415"
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Urheilutalo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Urheilutalo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.947580177176",
+          "60.186744870506"
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Herttoniemi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Herttoniemi",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.029891757469",
+          "60.195233041152"
+        ]
+      }
+    },
+    {
+      "id": 25,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hämeentie 161, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hämeentie 161",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.980143793994",
+          "60.214369842167"
+        ]
+      }
+    },
+    {
+      "id": 26,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Suomenoja, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Suomenoja",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.706886527939",
+          "60.15883237461"
+        ]
+      }
+    },
+    {
+      "id": 27,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hakaniemi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951481775302",
+          "60.178934729274"
+        ]
+      }
+    },
+    {
+      "id": 28,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ilmalantori 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ilmalantori 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.919471623789",
+          "60.207048855812"
+        ]
+      }
+    },
+    {
+      "id": 29,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Isonnevantie 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.889656796521",
+          "60.211605415072"
+        ]
+      }
+    },
+    {
+      "id": 30,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaikukatu 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kaikukatu 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.96043166316",
+          "60.183053045463"
+        ]
+      }
+    },
+    {
+      "id": 31,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kemistintie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kemistintie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.824476389831",
+          "60.183115161058"
+        ]
+      }
+    },
+    {
+      "id": 32,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kokkokalliontie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kokkokalliontie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.851314139189",
+          "60.228507111676"
+        ]
+      }
+    },
+    {
+      "id": 33,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Linnanmäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Linnanmäki",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 34,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mäkelänkatu 49, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mäkelänkatu 49",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.947459480595",
+          "60.200075094659"
+        ]
+      }
+    },
+    {
+      "id": 35,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautatientori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rautatientori",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.943797917613",
+          "60.171135618574"
+        ]
+      }
+    },
+    {
+      "id": 36,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ulvilantie 29, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.874732400873",
+          "60.207261561801"
+        ]
+      }
+    },
+    {
+      "id": 37,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Majurinkulma 2, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Majurinkulma 2",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.825398078335",
+          "60.211230757219"
+        ]
+      }
+    },
+    {
+      "id": 38,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Korso, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Korso",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.077326229122",
+          "60.350842571464"
+        ]
+      }
+    },
+    {
+      "id": 39,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viljelijäntie 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.856704168535",
+          "60.243497980417"
+        ]
+      }
+    },
+    {
+      "id": 40,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautatieasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rautatieasema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941008656398",
+          "60.171245203365"
+        ]
+      }
+    },
+    {
+      "id": 41,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinki",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 42,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kuunsilta, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.724406488338",
+          "60.172659241392"
+        ]
+      }
+    },
+    {
+      "id": 43,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ulvilantie 11a, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ulvilantie 11a",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.873520069955",
+          "60.204397262476"
+        ]
+      }
+    },
+    {
+      "id": 44,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kutojantie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kutojantie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.753170525089",
+          "60.209344562725"
+        ]
+      }
+    },
+    {
+      "id": 45,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruoholahti metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.913838597329",
+          "60.162710576292"
+        ]
+      }
+    },
+    {
+      "id": 46,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sotungin lukio, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sotungin lukio",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.120996858417",
+          "60.279409184806"
+        ]
+      }
+    },
+    {
+      "id": 47,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Näyttelijäntie 22, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Näyttelijäntie 22",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.893659033348",
+          "60.232088444648"
+        ]
+      }
+    },
+    {
+      "id": 48,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Leppävaara, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.811809503675",
+          "60.219724905957"
+        ]
+      }
+    },
+    {
+      "id": 49,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hotel Sokos Tapiola Garden, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.806919291134",
+          "60.177074678393"
+        ]
+      }
+    },
+    {
+      "id": 50,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Martinlaaksontie 36, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Martinlaaksontie 36",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.846188595487",
+          "60.275411497444"
+        ]
+      }
+    },
+    {
+      "id": 51,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pasilanraitio 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pasilanraitio 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.926488057133",
+          "60.196839261135"
+        ]
+      }
+    },
+    {
+      "id": 52,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Physicum Kumpula, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.963533117935",
+          "60.204644810048"
+        ]
+      }
+    },
+    {
+      "id": 53,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Siltakylänkuja 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Siltakylänkuja 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.987015113959",
+          "60.268946791883"
+        ]
+      }
+    },
+    {
+      "id": 54,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Koskelan sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Koskelan sairaala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.962056087798",
+          "60.215794741713"
+        ]
+      }
+    },
+    {
+      "id": 55,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kapteeninkatu 26, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kapteeninkatu 26",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.945881634736",
+          "60.159012096634"
+        ]
+      }
+    },
+    {
+      "id": 56,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauppakorkeakoulut, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kauppakorkeakoulut",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.924870084422",
+          "60.170721458641"
+        ]
+      }
+    },
+    {
+      "id": 57,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Laakson sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Laakson sairaala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.915786861794",
+          "60.191958833523"
+        ]
+      }
+    },
+    {
+      "id": 58,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölön ala-asteen koulu, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölön ala-asteen koulu",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.921451602205",
+          "60.183105196964"
+        ]
+      }
+    },
+    {
+      "id": 59,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kantvik, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kantvik",
+            "localadmin": "Kirkkonummi"
+          }
+        ],
+        "coordinates": [
+          "24.397301534607",
+          "60.092194124998"
+        ]
+      }
+    },
+    {
+      "id": 60,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keilaniementie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keilaniementie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.829301366495",
+          "60.174342577397"
+        ]
+      }
+    },
+    {
+      "id": 61,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kontula metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.083470537506",
+          "60.236159419389"
+        ]
+      }
+    },
+    {
+      "id": 62,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinki-Vantaa lentoasema T1, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinki-Vantaa lentoasema T1",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.97081970311",
+          "60.315740808542"
+        ]
+      }
+    },
+    {
+      "id": 63,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tapiola, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tapiola",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.804171543642",
+          "60.175233367125"
+        ]
+      }
+    },
+    {
+      "id": 64,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hämeentie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hämeentie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.950683374921",
+          "60.179990650058"
+        ]
+      }
+    },
+    {
+      "id": 65,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lapinrinne 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lapinrinne 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.927314727503",
+          "60.166692108569"
+        ]
+      }
+    },
+    {
+      "id": 66,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mäkelänkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mäkelänkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.962031632624",
+          "60.190312033076"
+        ]
+      }
+    },
+    {
+      "id": 67,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Väinö Auerin katu 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Väinö Auerin katu 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.965078542909",
+          "60.20814319718"
+        ]
+      }
+    },
+    {
+      "id": 68,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Agricolankatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Agricolankatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.956404937277",
+          "60.184643973241"
+        ]
+      }
+    },
+    {
+      "id": 69,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kluuvi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kluuvi",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 70,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Opastinsilta 12, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Opastinsilta 12",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.936394857679",
+          "60.199040628207"
+        ]
+      }
+    },
+    {
+      "id": 71,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Piispansilta 11, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Piispansilta 11",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.738136587983",
+          "60.162306248154"
+        ]
+      }
+    },
+    {
+      "id": 72,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kerava, Kerava"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kerava",
+            "localadmin": "Kerava"
+          }
+        ],
+        "coordinates": [
+          "25.104465253667",
+          "60.404502919604"
+        ]
+      }
+    },
+    {
+      "id": 73,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautalammintie 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rautalammintie 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.952144598568",
+          "60.198102737716"
+        ]
+      }
+    },
+    {
+      "id": 74,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoonlahti, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoonlahti",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655751645441",
+          "60.149293645516"
+        ]
+      }
+    },
+    {
+      "id": 75,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kuusilahdenkuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kuusilahdenkuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.856733443453",
+          "60.185118794619"
+        ]
+      }
+    },
+    {
+      "id": 76,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tapiolansolmu, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tapiolansolmu",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.810066957196",
+          "60.170260762458"
+        ]
+      }
+    },
+    {
+      "id": 77,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Siltavuorenpenger 10, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Siltavuorenpenger 10",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951771962249",
+          "60.17526145123"
+        ]
+      }
+    },
+    {
+      "id": 78,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Maininkitie 4, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Maininkitie 4",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.64614932973",
+          "60.151701414523"
+        ]
+      }
+    },
+    {
+      "id": 79,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Suvela, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Suvela",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.6671737603",
+          "60.202148478655"
+        ]
+      }
+    },
+    {
+      "id": 80,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Asema-aukio 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Asema-aukio 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941490869148",
+          "60.171098163892"
+        ]
+      }
+    },
+    {
+      "id": 81,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kasarmikatu 13, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kasarmikatu 13",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.948835628893",
+          "60.16153120684"
+        ]
+      }
+    },
+    {
+      "id": 82,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kirkkonummi, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kirkkonummi",
+            "localadmin": "Kirkkonummi"
+          }
+        ],
+        "coordinates": [
+          "24.439847005632",
+          "60.119731551314"
+        ]
+      }
+    },
+    {
+      "id": 83,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Arkadiankatu 21, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Arkadiankatu 21",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.925955239292",
+          "60.171512749282"
+        ]
+      }
+    },
+    {
+      "id": 84,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hesperian puisto, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hesperian puisto",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.930090316334",
+          "60.179499378608"
+        ]
+      }
+    },
+    {
+      "id": 85,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kannelmäen asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kannelmäen asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.876769292621",
+          "60.239668969999"
+        ]
+      }
+    },
+    {
+      "id": 86,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Valimotie 17, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Valimotie 17",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.87945925396",
+          "60.219455479322"
+        ]
+      }
+    },
+    {
+      "id": 87,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Telakkakatu 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Telakkakatu 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.931369701351",
+          "60.159123827442"
+        ]
+      }
+    },
+    {
+      "id": 88,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kirstinharju 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kirstinharju 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.665266810048",
+          "60.201475900847"
+        ]
+      }
+    },
+    {
+      "id": 89,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Nikinmäki, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Nikinmäki",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.137301694134",
+          "60.338782326999"
+        ]
+      }
+    },
+    {
+      "id": 90,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Haartmaninkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Haartmaninkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.911914371969",
+          "60.188825973537"
+        ]
+      }
+    },
+    {
+      "id": 91,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Riihimäki, Riihimäki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Riihimäki"
+          }
+        ],
+        "coordinates": [
+          "24.78167022417",
+          "60.735140078721"
+        ]
+      }
+    },
+    {
+      "id": 92,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Westend, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Westend",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 93,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kylänevantie 16, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kylänevantie 16",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.893270260694",
+          "60.213151925406"
+        ]
+      }
+    },
+    {
+      "id": 94,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tilanhoitajankaari 11, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tilanhoitajankaari 11",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.029001120049",
+          "60.230138979426"
+        ]
+      }
+    },
+    {
+      "id": 95,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ylioppilastalo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ylioppilastalo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.942466944475",
+          "60.168694630655"
+        ]
+      }
+    },
+    {
+      "id": 96,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Katriinan sairaala, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Katriinan sairaala",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.874255301492",
+          "60.346533191688"
+        ]
+      }
+    },
+    {
+      "id": 97,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Olympiastadion, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Olympiastadion",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.926893015571",
+          "60.186900026156"
+        ]
+      }
+    },
+    {
+      "id": 98,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Konemies, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.823302371168",
+          "60.187332132279"
+        ]
+      }
+    },
+    {
+      "id": 99,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Maapadontie 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Maapadontie 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.94798378154",
+          "60.230760200432"
+        ]
+      }
+    },
+    {
+      "id": 100,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Porkkalankatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Porkkalankatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.913284012135",
+          "60.165443100853"
+        ]
+      }
+    },
+    {
+      "id": 101,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Topeliuksenkatu 41, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Topeliuksenkatu 41",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.912187082753",
+          "60.189560127252"
+        ]
+      }
+    },
+    {
+      "id": 102,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Juhana Herttuan tie 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Juhana Herttuan tie 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.969794044525",
+          "60.217587478688"
+        ]
+      }
+    },
+    {
+      "id": 103,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mellunmäki metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.110170968182",
+          "60.23889198972"
+        ]
+      }
+    },
+    {
+      "id": 104,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pihatörmä 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pihatörmä 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.730716671483",
+          "60.164752860212"
+        ]
+      }
+    },
+    {
+      "id": 105,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hanasaari, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 106,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pajamäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pajamäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.854377066027",
+          "60.219296169839"
+        ]
+      }
+    },
+    {
+      "id": 107,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Siltakuja 2, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Siltakuja 2",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655882896507",
+          "60.202904865393"
+        ]
+      }
+    },
+    {
+      "id": 108,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pariisinkuja 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pariisinkuja 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.970324400102",
+          "60.201947392987"
+        ]
+      }
+    },
+    {
+      "id": 109,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pohjoinen Hesperiankatu 17, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pohjoinen Hesperiankatu 17",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.923311002436",
+          "60.177437393265"
+        ]
+      }
+    },
+    {
+      "id": 110,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinginkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinginkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.960664835272",
+          "60.187952268607"
+        ]
+      }
+    },
+    {
+      "id": 111,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Meilahden liikuntapuisto, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Meilahden liikuntapuisto",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.8983062697",
+          "60.190175461554"
+        ]
+      }
+    },
+    {
+      "id": 112,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Konala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Konala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.847062694718",
+          "60.237896090614"
+        ]
+      }
+    },
+    {
+      "id": 113,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mäkelänkatu 84, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mäkelänkatu 84",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.94383604831",
+          "60.21015402018"
+        ]
+      }
+    },
+    {
+      "id": 114,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruskeasuon varikko, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.898765866297",
+          "60.206993245652"
+        ]
+      }
+    },
+    {
+      "id": 115,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsingin rautatieasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsingin rautatieasema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941008656398",
+          "60.171245203365"
+        ]
+      }
+    },
+    {
+      "id": 116,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Höyläämötie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Höyläämötie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.878834379837",
+          "60.214980652525"
+        ]
+      }
+    },
+    {
+      "id": 117,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Matinniitynkuja 4, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Matinniitynkuja 4",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.743835860989",
+          "60.159473944837"
+        ]
+      }
+    },
+    {
+      "id": 118,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Otaniementie 19, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Otaniementie 19",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.818010986968",
+          "60.186916076127"
+        ]
+      }
+    },
+    {
+      "id": 119,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Radiokatu 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Radiokatu 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.924040242474",
+          "60.202762516666"
+        ]
+      }
+    },
+    {
+      "id": 120,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Entresse, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.657516045908",
+          "60.203417372459"
+        ]
+      }
+    },
+    {
+      "id": 121,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaivoksela, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kaivoksela",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.870600732291",
+          "60.265739452262"
+        ]
+      }
+    },
+    {
+      "id": 122,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kilonrinne 10, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kilonrinne 10",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.778822483777",
+          "60.220963739797"
+        ]
+      }
+    },
+    {
+      "id": 123,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lentoasema T2, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 124,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinki-Vantaa lentoasema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.968176616303",
+          "60.318758015899"
+        ]
+      }
+    },
+    {
+      "id": 125,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Maapadontie 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Maapadontie 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.947296358251",
+          "60.231330592341"
+        ]
+      }
+    },
+    {
+      "id": 126,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jakomäentie 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jakomäentie 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.071779161658",
+          "60.259008740058"
+        ]
+      }
+    },
+    {
+      "id": 127,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tennistie 1, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tennistie 1",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.05275981043",
+          "60.301832903696"
+        ]
+      }
+    },
+    {
+      "id": 128,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tyynenmerenkatu 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tyynenmerenkatu 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.920905914948",
+          "60.154592236068"
+        ]
+      }
+    },
+    {
+      "id": 129,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jätkäsaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jätkäsaari",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 130,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hämeentie 153, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hämeentie 153",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.979009509751",
+          "60.211416129033"
+        ]
+      }
+    },
+    {
+      "id": 131,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karstulantie 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Karstulantie 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.952573248013",
+          "60.198584364686"
+        ]
+      }
+    },
+    {
+      "id": 132,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Orionintie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Orionintie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.777382076881",
+          "60.177619112133"
+        ]
+      }
+    },
+    {
+      "id": 133,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Avaruuskatu 3, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Avaruuskatu 3",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.727165038723",
+          "60.169493646708"
+        ]
+      }
+    },
+    {
+      "id": 134,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hyljeluodontie 3, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hyljeluodontie 3",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.712465749748",
+          "60.156181582358"
+        ]
+      }
+    },
+    {
+      "id": 135,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Berghälls kyrka, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Berghälls kyrka",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.949518,
+            60.184207
+          ]
+        ]
+      }
+    },
+    {
+      "id": 136,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Otakaari 4, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Otakaari 4",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.827112488753",
+          "60.18689553958"
+        ]
+      }
+    },
+    {
+      "id": 137,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Eteläinen Rautatiekatu 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Eteläinen Rautatiekatu 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.932221871583",
+          "60.170777686504"
+        ]
+      }
+    },
+    {
+      "id": 138,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Järvenperä, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Järvenperä",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 139,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Teollisuuskatu 21, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Teollisuuskatu 21",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.948285341551",
+          "60.194324555998"
+        ]
+      }
+    },
+    {
+      "id": 140,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kansaneläkelaitos, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kansaneläkelaitos",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.91708806704",
+          "60.189490429417"
+        ]
+      }
+    },
+    {
+      "id": 141,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hakaniemenranta 12, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hakaniemenranta 12",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.959047959007",
+          "60.178862275198"
+        ]
+      }
+    },
+    {
+      "id": 142,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mankkaa, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mankkaa",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 143,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Arabianranta, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Arabianranta",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.974392933664",
+          "60.206585107011"
+        ]
+      }
+    },
+    {
+      "id": 144,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tuomarilan asema, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tuomarilan asema",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.683539875321",
+          "60.206158101961"
+        ]
+      }
+    },
+    {
+      "id": 145,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Linja-autoasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.932443490438",
+          "60.169061709703"
+        ]
+      }
+    },
+    {
+      "id": 146,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lapinmäentie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lapinmäentie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.881059921008",
+          "60.207830061305"
+        ]
+      }
+    },
+    {
+      "id": 147,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Munkkiniemen aukio, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.88487425087",
+          "60.196100093212"
+        ]
+      }
+    },
+    {
+      "id": 148,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinginkatu 26, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinginkatu 26",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.949238454825",
+          "60.186122644124"
+        ]
+      }
+    },
+    {
+      "id": 149,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautatientori metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941127348533",
+          "60.170355734682"
+        ]
+      }
+    },
+    {
+      "id": 150,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Finlandia-talo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Finlandia-talo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.932821199905",
+          "60.176033412652"
+        ]
+      }
+    },
+    {
+      "id": 151,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsingin päärautatieasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsingin päärautatieasema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941008656398",
+          "60.171245203365"
+        ]
+      }
+    },
+    {
+      "id": 152,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karhunkierros 1, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.810411764152",
+          "60.25740477401"
+        ]
+      }
+    },
+    {
+      "id": 153,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karakaari 7, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Karakaari 7",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.756448118297",
+          "60.221667573853"
+        ]
+      }
+    },
+    {
+      "id": 154,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Käenkuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Käenkuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.962145331783",
+          "60.185571865674"
+        ]
+      }
+    },
+    {
+      "id": 155,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Toinen Linja 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Toinen Linja 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.946969302722",
+          "60.181803450298"
+        ]
+      }
+    },
+    {
+      "id": 156,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hattulantie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hattulantie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.957489299171",
+          "60.195892076723"
+        ]
+      }
+    },
+    {
+      "id": 157,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kitarakuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kitarakuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.877202372114",
+          "60.238310756031"
+        ]
+      }
+    },
+    {
+      "id": 158,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Otaniemi, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Otaniemi",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.83470903446",
+          "60.188652103573"
+        ]
+      }
+    },
+    {
+      "id": 159,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaustisenpolku 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kaustisenpolku 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.881712709253",
+          "60.238882265046"
+        ]
+      }
+    },
+    {
+      "id": 160,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Talontie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Talontie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.890643192826",
+          "60.209399701629"
+        ]
+      }
+    },
+    {
+      "id": 161,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kutomotie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kutomotie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.8729394165",
+          "60.215127267456"
+        ]
+      }
+    },
+    {
+      "id": 162,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Suurpelto, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Suurpelto",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.742153810267",
+          "60.187119825648"
+        ]
+      }
+    },
+    {
+      "id": 163,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "WeeGee-talo, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "WeeGee-talo",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.795537237366",
+          "60.178794997144"
+        ]
+      }
+    },
+    {
+      "id": 164,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Savio, Kerava"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Savio",
+            "localadmin": "Kerava"
+          }
+        ],
+        "coordinates": [
+          "25.097562566263",
+          "60.381635386029"
+        ]
+      }
+    },
+    {
+      "id": 165,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tukholmankatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tukholmankatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.910445492071",
+          "60.191762226109"
+        ]
+      }
+    },
+    {
+      "id": 166,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Siltavuorenpenger 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Siltavuorenpenger 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.952544745439",
+          "60.175193070061"
+        ]
+      }
+    },
+    {
+      "id": 167,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Itsehallintotie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Itsehallintotie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.82106032143",
+          "60.211598746052"
+        ]
+      }
+    },
+    {
+      "id": 168,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jämeräntaival 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jämeräntaival 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.835002902115",
+          "60.18744748746"
+        ]
+      }
+    },
+    {
+      "id": 169,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.890480837655",
+          "60.236687495706"
+        ]
+      }
+    },
+    {
+      "id": 170,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Antti Korpin tie 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Antti Korpin tie 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.965633598314",
+          "60.219053973316"
+        ]
+      }
+    },
+    {
+      "id": 171,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mannerheimintie 46, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mannerheimintie 46",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.927570600167",
+          "60.178969490644"
+        ]
+      }
+    },
+    {
+      "id": 172,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinginkatu 24, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinginkatu 24",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.950375267143",
+          "60.186168359354"
+        ]
+      }
+    },
+    {
+      "id": 173,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Muusantori 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Muusantori 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.85630016571",
+          "60.207938288914"
+        ]
+      }
+    },
+    {
+      "id": 174,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Juustenintie 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Juustenintie 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.868155441084",
+          "60.245030286314"
+        ]
+      }
+    },
+    {
+      "id": 175,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keilaranta 17, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keilaranta 17",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.835253621299",
+          "60.178864970552"
+        ]
+      }
+    },
+    {
+      "id": 176,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lommila, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lommila",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.659540261595",
+          "60.218926241095"
+        ]
+      }
+    },
+    {
+      "id": 177,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pohjolankatu 38, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pohjolankatu 38",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.953083877465",
+          "60.216819908436"
+        ]
+      }
+    },
+    {
+      "id": 178,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoonlahden uimahalli, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoonlahden uimahalli",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.659010715196",
+          "60.146620663612"
+        ]
+      }
+    },
+    {
+      "id": 179,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kuninkaantien lukio, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kuninkaantien lukio",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.66053492868",
+          "60.209173733848"
+        ]
+      }
+    },
+    {
+      "id": 180,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viikinkaari 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viikinkaari 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.016709864233",
+          "60.225458427649"
+        ]
+      }
+    },
+    {
+      "id": 181,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Munkkiniemen puistotie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Munkkiniemen puistotie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.883977856477",
+          "60.19695878119"
+        ]
+      }
+    },
+    {
+      "id": 182,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Paavalin kirkko, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Paavalin kirkko",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.959876331021",
+          "60.197373820745"
+        ]
+      }
+    },
+    {
+      "id": 183,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Westendinasema, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Westendinasema",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.8043176967",
+          "60.168680105172"
+        ]
+      }
+    },
+    {
+      "id": 184,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ida Aalbergin tie, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ida Aalbergin tie",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.900351099914",
+          "60.230625039413"
+        ]
+      }
+    },
+    {
+      "id": 185,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Malmin sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Malmin sairaala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.998408435399",
+          "60.253835870087"
+        ]
+      }
+    },
+    {
+      "id": 186,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ilkantie 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ilkantie 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.90203654356",
+          "60.22233781904"
+        ]
+      }
+    },
+    {
+      "id": 187,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mäkkylä, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mäkkylä",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.83984365141",
+          "60.221731615615"
+        ]
+      }
+    },
+    {
+      "id": 188,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mellunmäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mellunmäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.111478933032",
+          "60.239132379178"
+        ]
+      }
+    },
+    {
+      "id": 189,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tapanilan asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tapanilan asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.029701119174",
+          "60.263389791369"
+        ]
+      }
+    },
+    {
+      "id": 190,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jokiniementie 31, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jokiniementie 31",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.074073910713",
+          "60.283844956267"
+        ]
+      }
+    },
+    {
+      "id": 191,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Salmisaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Salmisaari",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 192,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vantaanportti, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.958843190755",
+          "60.295443502894"
+        ]
+      }
+    },
+    {
+      "id": 193,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lakelankatu 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lakelankatu 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.659435792059",
+          "60.208326511608"
+        ]
+      }
+    },
+    {
+      "id": 194,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Niittykumpu, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Niittykumpu",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.767550848626",
+          "60.170962464378"
+        ]
+      }
+    },
+    {
+      "id": 195,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauppakeskus Kaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kauppakeskus Kaari",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.890480837655",
+          "60.236687495706"
+        ]
+      }
+    },
+    {
+      "id": 196,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Porthania, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Porthania",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.94830895595",
+          "60.170134020749"
+        ]
+      }
+    },
+    {
+      "id": 197,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauppakorkeakoulu, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.923004025637",
+          "60.171632061596"
+        ]
+      }
+    },
+    {
+      "id": 198,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rälssintie 16, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rälssintie 16",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.989382438268",
+          "60.241408842154"
+        ]
+      }
+    },
+    {
+      "id": 199,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kulosaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kulosaari",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.008561024804",
+          "60.187506953031"
+        ]
+      }
+    },
+    {
+      "id": 200,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tikkurilan lukio, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tikkurilan lukio",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.049896124119",
+          "60.298830637403"
+        ]
+      }
+    },
+    {
+      "id": 201,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Avaruuskatu 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Avaruuskatu 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.725679558782",
+          "60.169115825674"
+        ]
+      }
+    },
+    {
+      "id": 202,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Metsänpojankuja 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Metsänpojankuja 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.807106886361",
+          "60.186192997577"
+        ]
+      }
+    },
+    {
+      "id": 203,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Siltavuorenpenger 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Siltavuorenpenger 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.954115018838",
+          "60.175908839598"
+        ]
+      }
+    },
+    {
+      "id": 204,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Välimerenkatu 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Välimerenkatu 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.918992835677",
+          "60.160242449385"
+        ]
+      }
+    },
+    {
+      "id": 205,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mannerheimintie 50, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mannerheimintie 50",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.927183033075",
+          "60.179923656204"
+        ]
+      }
+    },
+    {
+      "id": 206,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tasetie 8, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tasetie 8",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.969559689038",
+          "60.290312341199"
+        ]
+      }
+    },
+    {
+      "id": 207,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Itäkeskus metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.077971872866",
+          "60.209984861837"
+        ]
+      }
+    },
+    {
+      "id": 208,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruoholahti, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ruoholahti",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.913754537773",
+          "60.162926579665"
+        ]
+      }
+    },
+    {
+      "id": 209,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Metsänpojankuja 3, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Metsänpojankuja 3",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.806155528867",
+          "60.186351372153"
+        ]
+      }
+    },
+    {
+      "id": 210,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Areenankuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Areenankuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92919955735",
+          "60.205383370089"
+        ]
+      }
+    },
+    {
+      "id": 211,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jan-magnus Janssonin aukio 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jan-magnus Janssonin aukio 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.966235443663",
+          "60.201483553804"
+        ]
+      }
+    },
+    {
+      "id": 212,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Klaneettitie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Klaneettitie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.878014381945",
+          "60.237623224184"
+        ]
+      }
+    },
+    {
+      "id": 213,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kumpula, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kumpula",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 214,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Postintaival 7, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Postintaival 7",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.918354872296",
+          "60.212908903498"
+        ]
+      }
+    },
+    {
+      "id": 215,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Takomotie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Takomotie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.876453839757",
+          "60.217033919854"
+        ]
+      }
+    },
+    {
+      "id": 216,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruosilantie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ruosilantie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.858661964293",
+          "60.236897077843"
+        ]
+      }
+    },
+    {
+      "id": 217,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsingin asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941008656398",
+          "60.171245203365"
+        ]
+      }
+    },
+    {
+      "id": 218,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Käpyläntie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Käpyläntie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.96056918389",
+          "60.21491688915"
+        ]
+      }
+    },
+    {
+      "id": 219,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Runeberginkatu 14, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Runeberginkatu 14",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.922612286132",
+          "60.171796355883"
+        ]
+      }
+    },
+    {
+      "id": 220,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hartwall Areena, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.928957043347",
+          "60.205097837397"
+        ]
+      }
+    },
+    {
+      "id": 221,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Finlands nationalmuseum, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Finlands nationalmuseum",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.931558,
+            60.175009
+          ]
+
+        ]
+      }
+    },
+    {
+      "id": 222,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ratapihantie 9, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ratapihantie 9",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.934947003213",
+          "60.20011898062"
+        ]
+      }
+    },
+    {
+      "id": 223,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Bulevardi 31, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Bulevardi 31",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.93150016156",
+          "60.163099289178"
+        ]
+      }
+    },
+    {
+      "id": 224,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Isonnevantie 16, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Isonnevantie 16",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.892014360912",
+          "60.215395372693"
+        ]
+      }
+    },
+    {
+      "id": 225,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ilmala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ilmala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.920769394354",
+          "60.207021904906"
+        ]
+      }
+    },
+    {
+      "id": 481,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Fölisön, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Fölisön",
+            "localadmin": "Helsingfors"
+          }
+        ]
+      }
+    },
+    {
+      "id": 227,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kettutie 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kettutie 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.036926267471",
+          "60.207340873545"
+        ]
+      }
+    },
+    {
+      "id": 228,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Otakaari 5, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Otakaari 5",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 229,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pihlajamäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pihlajamäki",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 230,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinginkatu 25, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinginkatu 25",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.950337800026",
+          "60.18674309273"
+        ]
+      }
+    },
+    {
+      "id": 231,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Latokaski, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Latokaski",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655163362075",
+          "60.177650849175"
+        ]
+      }
+    },
+    {
+      "id": 232,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Saunalahti, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Saunalahti",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 233,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Valimotie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Valimotie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.876772675538",
+          "60.215461034668"
+        ]
+      }
+    },
+    {
+      "id": 234,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Akanapolku 2, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Akanapolku 2",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.06071336395",
+          "60.299444893989"
+        ]
+      }
+    },
+    {
+      "id": 235,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Messukeskus, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Messukeskus",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.936293930516",
+          "60.202461187774"
+        ]
+      }
+    },
+    {
+      "id": 236,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vaskivuoren lukio, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vaskivuoren lukio",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.851336042257",
+          "60.266241276979"
+        ]
+      }
+    },
+    {
+      "id": 237,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Aleksanterinkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.957640038034",
+          "60.169492487719"
+        ]
+      }
+    },
+    {
+      "id": 238,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Alvar Aallon kuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.938917704035",
+          "60.174994049307"
+        ]
+      }
+    },
+    {
+      "id": 239,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pasila, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pasila",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.933818440147",
+          "60.198475349264"
+        ]
+      }
+    },
+    {
+      "id": 240,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölönkatu 51, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92004350472",
+          "60.184308777652"
+        ]
+      }
+    },
+    {
+      "id": 241,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Auroran sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Auroran sairaala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.925054614865",
+          "60.192029167674"
+        ]
+      }
+    },
+    {
+      "id": 242,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Louhela, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Louhela",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.85785739011",
+          "60.270346144704"
+        ]
+      }
+    },
+    {
+      "id": 243,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lääkärinkatu 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.917476050722",
+          "60.193060180686"
+        ]
+      }
+    },
+    {
+      "id": 244,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karstulantie 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Karstulantie 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.953601361292",
+          "60.197975586489"
+        ]
+      }
+    },
+    {
+      "id": 245,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Prinsessantie 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Prinsessantie 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.059209208636",
+          "60.206500627168"
+        ]
+      }
+    },
+    {
+      "id": 246,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Itämerenkatu 21, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Itämerenkatu 21",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.910355204972",
+          "60.163748829202"
+        ]
+      }
+    },
+    {
+      "id": 247,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vuolukiventie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.006240115643",
+          "60.237126264179"
+        ]
+      }
+    },
+    {
+      "id": 248,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pukinmäen asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pukinmäen asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.993892281523",
+          "60.242479209717"
+        ]
+      }
+    },
+    {
+      "id": 249,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keilalahdentie 2, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keilalahdentie 2",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.827400500621",
+          "60.171114157689"
+        ]
+      }
+    },
+    {
+      "id": 250,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Merihaka, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Merihaka",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.960404653401",
+          "60.179040953539"
+        ]
+      }
+    },
+    {
+      "id": 251,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Unioninkatu 40, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Unioninkatu 40",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.949894668568",
+          "60.172644935434"
+        ]
+      }
+    },
+    {
+      "id": 252,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mäkelänrinteen lukio, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mäkelänrinteen lukio",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.948947274481",
+          "60.198520590203"
+        ]
+      }
+    },
+    {
+      "id": 253,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölön sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölön sairaala",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.921745678772",
+          "60.181379764764"
+        ]
+      }
+    },
+    {
+      "id": 254,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Biomedicum, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Biomedicum",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.906187991733",
+          "60.190337274542"
+        ]
+      }
+    },
+    {
+      "id": 255,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Huokotie 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Huokotie 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.081205146318",
+          "60.261643128002"
+        ]
+      }
+    },
+    {
+      "id": 256,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kirkkonummen asema, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kirkkonummen asema",
+            "localadmin": "Kirkkonummi"
+          }
+        ],
+        "coordinates": [
+          "24.439631895842",
+          "60.119786118813"
+        ]
+      }
+    },
+    {
+      "id": 257,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mannerheimintie 164, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mannerheimintie 164",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.900372949481",
+          "60.19916431717"
+        ]
+      }
+    },
+    {
+      "id": 258,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tähkäkuja 5, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tähkäkuja 5",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.062948188121",
+          "60.299759156062"
+        ]
+      }
+    },
+    {
+      "id": 259,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viherlaakso, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viherlaakso",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 260,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kevätkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kevätkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.029865085489",
+          "60.227762597904"
+        ]
+      }
+    },
+    {
+      "id": 261,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lehtimäki, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lehtimäki",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 262,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Haartmaninkatu 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Haartmaninkatu 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.905581404521",
+          "60.190565815844"
+        ]
+      }
+    },
+    {
+      "id": 263,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tenholantie 10, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tenholantie 10",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.907688619363",
+          "60.202256047501"
+        ]
+      }
+    },
+    {
+      "id": 264,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pitäjänmäen asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pitäjänmäen asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.860485700389",
+          "60.223143254257"
+        ]
+      }
+    },
+    {
+      "id": 265,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Gesterby, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Gesterby",
+            "localadmin": "Kirkkonummi"
+          }
+        ]
+      }
+    },
+    {
+      "id": 266,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölön Tulli, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölön Tulli",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.912546088063",
+          "60.190805316487"
+        ]
+      }
+    },
+    {
+      "id": 267,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Arentikuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Arentikuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.854481089495",
+          "60.244795845305"
+        ]
+      }
+    },
+    {
+      "id": 268,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Raumantie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.879210396559",
+          "60.205436787884"
+        ]
+      }
+    },
+    {
+      "id": 269,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoon asema, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoon asema",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.656614474073",
+          "60.205225944965"
+        ]
+      }
+    },
+    {
+      "id": 270,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kalajärvi, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kalajärvi",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 271,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Senaatintori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Senaatintori",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 272,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kutojantie 2, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kutojantie 2",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.752034444032",
+          "60.210140871316"
+        ]
+      }
+    },
+    {
+      "id": 273,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Aapelinkatu 5, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Aapelinkatu 5",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.749902265976",
+          "60.155409627948"
+        ]
+      }
+    },
+    {
+      "id": 274,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viikinkaari 11, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viikinkaari 11",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.012672070203",
+          "60.227356311756"
+        ]
+      }
+    },
+    {
+      "id": 275,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keran asema, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keran asema",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.753576498014",
+          "60.216038166156"
+        ]
+      }
+    },
+    {
+      "id": 276,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tikkurila, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tikkurila",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 277,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karakallio, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Karakallio",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 278,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Nordenskiöldinkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Nordenskiöldinkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.917879233845",
+          "60.186190775839"
+        ]
+      }
+    },
+    {
+      "id": 279,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Valimo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Valimo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.874200431473",
+          "60.221841898333"
+        ]
+      }
+    },
+    {
+      "id": 280,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Elielinaukio, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Elielinaukio",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.939589562539",
+          "60.171389907272"
+        ]
+      }
+    },
+    {
+      "id": 281,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Porvoonkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Porvoonkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951707441471",
+          "60.189228604023"
+        ]
+      }
+    },
+    {
+      "id": 282,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tilkka, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tilkka",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.898803469715",
+          "60.19979429826"
+        ]
+      }
+    },
+    {
+      "id": 283,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölöntullinkatu 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölöntullinkatu 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.913222062177",
+          "60.189831260637"
+        ]
+      }
+    },
+    {
+      "id": 284,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vanha Maantie 9, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vanha Maantie 9",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.804590289785",
+          "60.222569308768"
+        ]
+      }
+    },
+    {
+      "id": 285,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Santahamina, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Santahamina",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 286,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Näätätie 21, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Näätätie 21",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.039636756394",
+          "60.206933690836"
+        ]
+      }
+    },
+    {
+      "id": 287,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Karhupuisto, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Karhupuisto",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.953277563714",
+          "60.183697077927"
+        ]
+      }
+    },
+    {
+      "id": 288,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Naistenklinikka, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Naistenklinikka",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.910614081635",
+          "60.188736170967"
+        ]
+      }
+    },
+    {
+      "id": 289,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Itäkeskus, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Itäkeskus",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.078486202253",
+          "60.210267919622"
+        ]
+      }
+    },
+    {
+      "id": 290,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Väinö Auerin katu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Väinö Auerin katu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.967150218621",
+          "60.209286018524"
+        ]
+      }
+    },
+    {
+      "id": 291,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pasilan asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pasilan asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.933500837097",
+          "60.198719935766"
+        ]
+      }
+    },
+    {
+      "id": 292,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vantaankoski liityntäpysäköinti, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.848087045652",
+          "60.28661909688"
+        ]
+      }
+    },
+    {
+      "id": 293,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Valimotie 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Valimotie 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.877719508903",
+          "60.217815433424"
+        ]
+      }
+    },
+    {
+      "id": 294,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Energiakatu 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Energiakatu 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.903839464342",
+          "60.165875838629"
+        ]
+      }
+    },
+    {
+      "id": 295,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Linnoituksentie 10, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Linnoituksentie 10",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.0713198712",
+          "60.2421822604"
+        ]
+      }
+    },
+    {
+      "id": 296,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Suomenlinna, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Suomenlinna",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 297,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Forum, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Forum",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.938418172011",
+          "60.168849012993"
+        ]
+      }
+    },
+    {
+      "id": 298,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Olari, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Olari",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 299,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sibeliuksenkatu 14, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.918412420838",
+          "60.18075661882"
+        ]
+      }
+    },
+    {
+      "id": 300,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sello, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sello",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.810432886401",
+          "60.218772907458"
+        ]
+      }
+    },
+    {
+      "id": 301,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rantaharju 10, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rantaharju 10",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.756395901486",
+          "60.153550642575"
+        ]
+      }
+    },
+    {
+      "id": 302,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Musiikkitalo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Musiikkitalo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.93469896636",
+          "60.173632571794"
+        ]
+      }
+    },
+    {
+      "id": 303,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ida Aalbergin tie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ida Aalbergin tie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.900351099914",
+          "60.230625039413"
+        ]
+      }
+    },
+    {
+      "id": 304,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Piispansilta, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Piispansilta",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.735862182577",
+          "60.166106676043"
+        ]
+      }
+    },
+    {
+      "id": 305,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kamppi metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.930407267888",
+          "60.168402813112"
+        ]
+      }
+    },
+    {
+      "id": 306,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tyynenmerenkatu 11, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tyynenmerenkatu 11",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92123939186",
+          "60.156214578039"
+        ]
+      }
+    },
+    {
+      "id": 307,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sörnäinen metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.959891982409",
+          "60.187410326406"
+        ]
+      }
+    },
+    {
+      "id": 308,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kulttuuritalo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kulttuuritalo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.943856418135",
+          "60.188252462354"
+        ]
+      }
+    },
+    {
+      "id": 309,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hyvinkää"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hyvinkää"
+          }
+        ],
+        "coordinates": [
+          "24.857741898872",
+          "60.631325462747"
+        ]
+      }
+    },
+    {
+      "id": 310,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Arcada, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Arcada",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.967271314204",
+          "60.20114389313"
+        ]
+      }
+    },
+    {
+      "id": 311,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jakomäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jakomäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.078240923773",
+          "60.255554499819"
+        ]
+      }
+    },
+    {
+      "id": 312,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Peijaksen sairaala, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Peijaksen sairaala",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.059944254963",
+          "60.330992681758"
+        ]
+      }
+    },
+    {
+      "id": 313,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viikin tiedepuisto, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viikin tiedepuisto",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 314,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Peltokyläntie 3, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Peltokyläntie 3",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.981687050317",
+          "60.267819394661"
+        ]
+      }
+    },
+    {
+      "id": 315,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Heikintori, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Heikintori",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.80168336924",
+          "60.176639688385"
+        ]
+      }
+    },
+    {
+      "id": 316,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Peijas Hospital, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.059944254963",
+          "60.330992681758"
+        ]
+      }
+    },
+    {
+      "id": 317,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Käpylän asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Käpylän asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.944355430028",
+          "60.219440452822"
+        ]
+      }
+    },
+    {
+      "id": 318,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Söderkulla, Sipoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Söderkulla",
+            "localadmin": "Sipoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 319,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kätilöopisto, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951355903289",
+          "60.203870985492"
+        ]
+      }
+    },
+    {
+      "id": 320,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ikea Vantaa, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ikea Vantaa",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.083708141223",
+          "60.276702566557"
+        ]
+      }
+    },
+    {
+      "id": 321,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sörnäinen, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sörnäinen",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.963563568354",
+          "60.18784148177"
+        ]
+      }
+    },
+    {
+      "id": 322,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Innopoli, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.813569907763",
+          "60.185166171179"
+        ]
+      }
+    },
+    {
+      "id": 323,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sturenkatu 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sturenkatu 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.94452655056",
+          "60.1883643801"
+        ]
+      }
+    },
+    {
+      "id": 324,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Messuaukio 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Messuaukio 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.936767415074",
+          "60.201991094896"
+        ]
+      }
+    },
+    {
+      "id": 325,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Fabianinkatu 33, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Fabianinkatu 33",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.950127706142",
+          "60.169483701686"
+        ]
+      }
+    },
+    {
+      "id": 326,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Alvar Aallon puisto, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.829051452026",
+          "60.183732905676"
+        ]
+      }
+    },
+    {
+      "id": 327,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vanha Viertotie 23, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vanha Viertotie 23",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.883189251398",
+          "60.211899940062"
+        ]
+      }
+    },
+    {
+      "id": 328,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pasilanraitio 11, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pasilanraitio 11",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.926198415819",
+          "60.200638117512"
+        ]
+      }
+    },
+    {
+      "id": 329,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vuosaari metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.142792503899",
+          "60.207243228983"
+        ]
+      }
+    },
+    {
+      "id": 330,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Iivisniemi, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Iivisniemi",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.69022446392",
+          "60.149163509377"
+        ]
+      }
+    },
+    {
+      "id": 331,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Alppikatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.940437123564",
+          "60.184659421162"
+        ]
+      }
+    },
+    {
+      "id": 332,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Katajanokan terminaali, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Katajanokan terminaali",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.968342655789",
+          "60.164047067436"
+        ]
+      }
+    },
+    {
+      "id": 333,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Oulunkylän asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Oulunkylän asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.967662372806",
+          "60.229128207076"
+        ]
+      }
+    },
+    {
+      "id": 334,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tennispalatsi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tennispalatsi",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.930277129212",
+          "60.169534703722"
+        ]
+      }
+    },
+    {
+      "id": 335,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hattulantie 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hattulantie 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.956407507202",
+          "60.196510248922"
+        ]
+      }
+    },
+    {
+      "id": 336,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Munkkivuori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Munkkivuori",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 337,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tallberginkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tallberginkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.904198270929",
+          "60.161888054615"
+        ]
+      }
+    },
+    {
+      "id": 338,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Barona Areena, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Barona Areena",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.785212433837",
+          "60.177294732476"
+        ]
+      }
+    },
+    {
+      "id": 339,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Käpylä, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Käpylä",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 340,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Koivukylän asema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Koivukylän asema",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.06016748599",
+          "60.323917829665"
+        ]
+      }
+    },
+    {
+      "id": 341,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kirkkokatu 16, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kirkkokatu 16",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.653509523114",
+          "60.212323063387"
+        ]
+      }
+    },
+    {
+      "id": 342,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hiekkaharju, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hiekkaharju",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 343,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Huopalahden asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Huopalahden asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.894003368846",
+          "60.218218374529"
+        ]
+      }
+    },
+    {
+      "id": 344,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lintukorventie 2, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lintukorventie 2",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.820980211773",
+          "60.237270045657"
+        ]
+      }
+    },
+    {
+      "id": 345,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mikkola, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mikkola",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 346,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sturenkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sturenkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.943772231453",
+          "60.187831189224"
+        ]
+      }
+    },
+    {
+      "id": 347,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoon keskus, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoon keskus",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655388534116",
+          "60.206147522303"
+        ]
+      }
+    },
+    {
+      "id": 348,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Meilahti, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Meilahti",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 349,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Haartmaninkatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Haartmaninkatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.910355790092",
+          "60.189824034981"
+        ]
+      }
+    },
+    {
+      "id": 350,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Teekkarikylä, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Teekkarikylä",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.834184578594",
+          "60.188583595765"
+        ]
+      }
+    },
+    {
+      "id": 351,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Veikkola, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Veikkola",
+            "localadmin": "Kirkkonummi"
+          }
+        ]
+      }
+    },
+    {
+      "id": 352,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Munkkiniemi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Munkkiniemi",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 353,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jäähalli, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92194921184",
+          "60.189286187634"
+        ]
+      }
+    },
+    {
+      "id": 354,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Makasiiniterminaali, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Makasiiniterminaali",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.954092479895",
+          "60.16394393894"
+        ]
+      }
+    },
+    {
+      "id": 355,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Puustellinmäki, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Puustellinmäki",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.824416266717",
+          "60.220266535937"
+        ]
+      }
+    },
+    {
+      "id": 356,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rastila, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rastila",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.120485295225",
+          "60.20574595931"
+        ]
+      }
+    },
+    {
+      "id": 357,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Läntinen Brahenkatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Läntinen Brahenkatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.947920834951",
+          "60.187307924981"
+        ]
+      }
+    },
+    {
+      "id": 358,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Katajanokka, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Katajanokka",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.971648146487",
+          "60.167415836485"
+        ]
+      }
+    },
+    {
+      "id": 359,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Puistolan asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Puistolan asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.036290218862",
+          "60.27523178284"
+        ]
+      }
+    },
+    {
+      "id": 360,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lähderanta, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lähderanta",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.736943425393",
+          "60.244162690883"
+        ]
+      }
+    },
+    {
+      "id": 361,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hakaniemen tori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951481775302",
+          "60.178934729274"
+        ]
+      }
+    },
+    {
+      "id": 362,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kisahalli, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92551862301",
+          "60.183534653597"
+        ]
+      }
+    },
+    {
+      "id": 363,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaupinkalliontie 3, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kaupinkalliontie 3",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.801450852139",
+          "60.178929934478"
+        ]
+      }
+    },
+    {
+      "id": 364,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Nihtisilta, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Nihtisilta",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 365,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pohjois-Haaga, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pohjois-Haaga",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.884041760853",
+          "60.230178140365"
+        ]
+      }
+    },
+    {
+      "id": 366,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Meilahdentie 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Meilahdentie 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.895112734823",
+          "60.191390849709"
+        ]
+      }
+    },
+    {
+      "id": 367,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Nikkilä, Sipoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Nikkilä",
+            "localadmin": "Sipoo"
+          }
+        ],
+        "coordinates": [
+          "25.268521648693",
+          "60.376705468475"
+        ]
+      }
+    },
+    {
+      "id": 368,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lehtimäentie 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lehtimäentie 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.656010383503",
+          "60.212005554616"
+        ]
+      }
+    },
+    {
+      "id": 369,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Myyrmanni, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Myyrmanni",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.853315150009",
+          "60.260367388926"
+        ]
+      }
+    },
+    {
+      "id": 370,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mannerheimintie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mannerheimintie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.942203753257",
+          "60.168310532054"
+        ]
+      }
+    },
+    {
+      "id": 371,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kuusitie 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kuusitie 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.899342111092",
+          "60.19509623434"
+        ]
+      }
+    },
+    {
+      "id": 372,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mistelitie 26, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mistelitie 26",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.002526531422",
+          "60.31351291017"
+        ]
+      }
+    },
+    {
+      "id": 373,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruskeasuo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ruskeasuo",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.901893856752",
+          "60.202681528695"
+        ]
+      }
+    },
+    {
+      "id": 374,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lauttasaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lauttasaari",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 375,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Sofianlehdonkatu 5, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Sofianlehdonkatu 5",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.951308566803",
+          "60.204104700696"
+        ]
+      }
+    },
+    {
+      "id": 376,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vanha Maantie 6, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vanha Maantie 6",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.805078052185",
+          "60.221857263995"
+        ]
+      }
+    },
+    {
+      "id": 377,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsinki-Vantaan lentoasema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsinki-Vantaan lentoasema",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 378,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Matinkylä, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Matinkylä",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 379,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Puotila, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.09591849966",
+          "60.213760442189"
+        ]
+      }
+    },
+    {
+      "id": 380,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauppatori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kauppatori",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.95446119633",
+          "60.1673432068"
+        ]
+      }
+    },
+    {
+      "id": 381,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsingin jäähalli, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsingin jäähalli",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92194921184",
+          "60.189286187634"
+        ]
+      }
+    },
+    {
+      "id": 382,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hakunila, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Hakunila",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 383,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Soukka, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Soukka",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 384,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kiasma, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kiasma",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.936448960954",
+          "60.171816045682"
+        ]
+      }
+    },
+    {
+      "id": 385,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoontori, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoontori",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655034270064",
+          "60.204659311394"
+        ]
+      }
+    },
+    {
+      "id": 386,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kalasatama metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.976876110554",
+          "60.187582533442"
+        ]
+      }
+    },
+    {
+      "id": 387,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Malmi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.011939950239",
+          "60.251031680905"
+        ]
+      }
+    },
+    {
+      "id": 388,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jorvin sairaala, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jorvin sairaala",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.687436806068",
+          "60.221755657581"
+        ]
+      }
+    },
+    {
+      "id": 389,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Korson asema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Korson asema",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.078134665725",
+          "60.350638552791"
+        ]
+      }
+    },
+    {
+      "id": 390,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Iso Omena, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Iso Omena",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.738045945118",
+          "60.162279825349"
+        ]
+      }
+    },
+    {
+      "id": 391,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pajuniityntie 11, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pajuniityntie 11",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.90672174046",
+          "60.218194928664"
+        ]
+      }
+    },
+    {
+      "id": 392,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Martinlaakson asema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Martinlaakson asema",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.852757269326",
+          "60.278511027536"
+        ]
+      }
+    },
+    {
+      "id": 393,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ikea Espoo, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ikea Espoo",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.662779952996",
+          "60.216755949282"
+        ]
+      }
+    },
+    {
+      "id": 394,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaisaniemi metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.947272187716",
+          "60.171667357092"
+        ]
+      }
+    },
+    {
+      "id": 395,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tapanila, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tapanila",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 396,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tivolikuja 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tivolikuja 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.94054257707",
+          "60.18834780998"
+        ]
+      }
+    },
+    {
+      "id": 397,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Olympiaterminaali, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Olympiaterminaali",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.958622755158",
+          "60.160554212884"
+        ]
+      }
+    },
+    {
+      "id": 398,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Flamingo, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Flamingo",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.969940106271",
+          "60.290336493427"
+        ]
+      }
+    },
+    {
+      "id": 399,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kampin keskus, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.932316144717",
+          "60.169017725144"
+        ]
+      }
+    },
+    {
+      "id": 400,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Leiritie 1, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Leiritie 1",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.845330518164",
+          "60.258255272794"
+        ]
+      }
+    },
+    {
+      "id": 401,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaivokatu 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kaivokatu 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.940268699115",
+          "60.170568275064"
+        ]
+      }
+    },
+    {
+      "id": 402,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Teollisuuskatu 23, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Teollisuuskatu 23",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.946549367891",
+          "60.194767802079"
+        ]
+      }
+    },
+    {
+      "id": 403,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Otakaari 1, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Otakaari 1",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.828862173862",
+          "60.187665518055"
+        ]
+      }
+    },
+    {
+      "id": 404,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hakaniemi metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.950520317277",
+          "60.179336569142"
+        ]
+      }
+    },
+    {
+      "id": 405,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölöntori, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölöntori",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.923516459556",
+          "60.178979832991"
+        ]
+      }
+    },
+    {
+      "id": 406,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kivenlahti, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kivenlahti",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.63751387534",
+          "60.152039421538"
+        ]
+      }
+    },
+    {
+      "id": 407,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölönkatu 37, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölönkatu 37",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.922922964521",
+          "60.182233271819"
+        ]
+      }
+    },
+    {
+      "id": 408,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Herttoniemi metroasema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.031128412805",
+          "60.194999031381"
+        ]
+      }
+    },
+    {
+      "id": 409,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ratapihantie 13, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ratapihantie 13",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.933780948835",
+          "60.201599252362"
+        ]
+      }
+    },
+    {
+      "id": 410,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Ruusutorpantie 4, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Ruusutorpantie 4",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.804738060312",
+          "60.214606882713"
+        ]
+      }
+    },
+    {
+      "id": 411,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tuomarila, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tuomarila",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.68457788451",
+          "60.204043464521"
+        ]
+      }
+    },
+    {
+      "id": 412,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Meilahden sairaala, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.90571615923",
+          "60.188913320504"
+        ]
+      }
+    },
+    {
+      "id": 413,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Albertinkatu 32, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Albertinkatu 32",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.933401372295",
+          "60.163453933916"
+        ]
+      }
+    },
+    {
+      "id": 414,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Myyrmäen asema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Myyrmäen asema",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.855148881735",
+          "60.261414741427"
+        ]
+      }
+    },
+    {
+      "id": 415,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Arabia, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.976040692608",
+          "60.20862850512"
+        ]
+      }
+    },
+    {
+      "id": 416,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Maunula, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Maunula",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 417,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Oulunkylä, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Oulunkylä",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.963498154737",
+          "60.228673793592"
+        ]
+      }
+    },
+    {
+      "id": 418,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kantelettarentie 1, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kantelettarentie 1",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.889614585332",
+          "60.236029088062"
+        ]
+      }
+    },
+    {
+      "id": 419,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Rautatientori Metro Station, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.941127348533",
+          "60.170355734682"
+        ]
+      }
+    },
+    {
+      "id": 420,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Gustaf Hällströmin katu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Gustaf Hällströmin katu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.962504091879",
+          "60.204607398719"
+        ]
+      }
+    },
+    {
+      "id": 421,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Masala, Kirkkonummi"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Masala",
+            "localadmin": "Kirkkonummi"
+          }
+        ]
+      }
+    },
+    {
+      "id": 422,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Espoo, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Espoo",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 423,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Jorvi, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Jorvi",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.686588366609",
+          "60.220871456985"
+        ]
+      }
+    },
+    {
+      "id": 424,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lippulaiva, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lippulaiva",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.655502129666",
+          "60.149420539912"
+        ]
+      }
+    },
+    {
+      "id": 425,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Haartmaninkatu 4, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Haartmaninkatu 4",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.908278598564",
+          "60.190322976083"
+        ]
+      }
+    },
+    {
+      "id": 426,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Myllypuro, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Myllypuro",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 427,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Oopperatalo, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92888642169",
+          "60.181536391197"
+        ]
+      }
+    },
+    {
+      "id": 428,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Myyrmäki, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Myyrmäki",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "24.853761087638",
+          "60.262231488975"
+        ]
+      }
+    },
+    {
+      "id": 429,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pitäjänmäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pitäjänmäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.860654650666",
+          "60.223393482836"
+        ]
+      }
+    },
+    {
+      "id": 430,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lasipalatsi, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lasipalatsi",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.936335810401",
+          "60.170371706103"
+        ]
+      }
+    },
+    {
+      "id": 431,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Mannerheimvägen 172, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mannerheimvägen 172",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          "24.897278353203",
+          "60.206015961323"
+        ]
+      }
+    },
+    {
+      "id": 432,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keravan asema, Kerava"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keravan asema",
+            "localadmin": "Kerava"
+          }
+        ],
+        "coordinates": [
+          "25.105923607542",
+          "60.404167687258"
+        ]
+      }
+    },
+    {
+      "id": 433,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lentoasema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Lentoasema",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 434,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Malminkartano, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Malminkartano",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.862888758207",
+          "60.247990730455"
+        ]
+      }
+    },
+    {
+      "id": 435,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Töölön kisahalli, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Töölön kisahalli",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92551862301",
+          "60.183534653597"
+        ]
+      }
+    },
+    {
+      "id": 436,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tukholmankatu 10, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tukholmankatu 10",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.901561555662",
+          "60.191221514181"
+        ]
+      }
+    },
+    {
+      "id": 437,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vuosaari, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Vuosaari",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 438,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Länsiterminaali, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Länsiterminaali",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92026478311",
+          "60.15420174405"
+        ]
+      }
+    },
+    {
+      "id": 439,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Katajanokanlaituri 6, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Katajanokanlaituri 6",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.963668743535",
+          "60.16558910264"
+        ]
+      }
+    },
+    {
+      "id": 440,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Dipoli, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Dipoli",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.832508712035",
+          "60.185039679965"
+        ]
+      }
+    },
+    {
+      "id": 441,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Puistola, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Puistola",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.036369402572",
+          "60.274306635618"
+        ]
+      }
+    },
+    {
+      "id": 442,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kamppi terminal, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.932044205947",
+          "60.168956804947"
+        ]
+      }
+    },
+    {
+      "id": 443,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tavastvägen 135, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tavastvägen 135",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          "24.97677238057",
+          "60.208973185853"
+        ]
+      }
+    },
+    {
+      "id": 444,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauklahti, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kauklahti",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.597809535974",
+          "60.189473389677"
+        ]
+      }
+    },
+    {
+      "id": 445,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Martinlaakso, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Martinlaakso",
+            "localadmin": "Vantaa"
+          }
+        ]
+      }
+    },
+    {
+      "id": 446,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kannelmäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kannelmäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.87724697934",
+          "60.239979969815"
+        ]
+      }
+    },
+    {
+      "id": 447,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Keskuskatu 2, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Keskuskatu 2",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.942203753257",
+          "60.168310532054"
+        ]
+      }
+    },
+    {
+      "id": 448,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kilo, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kilo",
+            "localadmin": "Espoo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 449,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Pukinmäki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Pukinmäki",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.989844225444",
+          "60.243550662832"
+        ]
+      }
+    },
+    {
+      "id": 450,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kaapelitehdas, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.903507605831",
+          "60.161659387805"
+        ]
+      }
+    },
+    {
+      "id": 451,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Viikki, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Viikki",
+            "localadmin": "Helsinki"
+          }
+        ]
+      }
+    },
+    {
+      "id": 452,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Opastinsilta 8, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Opastinsilta 8",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.939045864984",
+          "60.199057794612"
+        ]
+      }
+    },
+    {
+      "id": 453,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Leppävaaran asema, Espoo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Leppävaaran asema",
+            "localadmin": "Espoo"
+          }
+        ],
+        "coordinates": [
+          "24.812164960127",
+          "60.21950731228"
+        ]
+      }
+    },
+    {
+      "id": 454,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Malmin asema, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Malmin asema",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.00925849453",
+          "60.250163460682"
+        ]
+      }
+    },
+    {
+      "id": 455,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Linnankatu 9, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Linnankatu 9",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.969871899219",
+          "60.165822126279"
+        ]
+      }
+    },
+    {
+      "id": 456,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tikkurilan asema, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tikkurilan asema",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.044105514477",
+          "60.292494308713"
+        ]
+      }
+    },
+    {
+      "id": 457,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kauniainen, Kauniainen"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kauniainen",
+            "localadmin": "Kauniainen"
+          }
+        ],
+        "coordinates": [
+          "24.732206670524",
+          "60.211499369355"
+        ]
+      }
+    },
+    {
+      "id": 458,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kumpulan kampus, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.963436367497",
+          "60.205650825369"
+        ]
+      }
+    },
+    {
+      "id": 459,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kontula, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Kontula",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "25.082556371921",
+          "60.23635537563"
+        ]
+      }
+    },
+    {
+      "id": 460,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Länsisatama, Helsinki"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Länsisatama",
+            "localadmin": "Helsinki"
+          }
+        ],
+        "coordinates": [
+          "24.92026478311",
+          "60.15420174405"
+        ]
+      }
+    },
+    {
+      "id": 461,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Koivukylä, Vantaa"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Koivukylä",
+            "localadmin": "Vantaa"
+          }
+        ],
+        "coordinates": [
+          "25.059419769242",
+          "60.323744267891"
+        ]
+      }
+    },
+    {
+      "id": 462,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Helsingfors-Vanda flygstation, Vanda"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Helsingfors-Vanda flygstation",
+            "localadmin": "Vanda"
+          }
+        ]
+      }
+    },
+    {
+      "id": 463,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Östra Böle, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Östra Böle",
+            "localadmin": "Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.938900290336445,
+            60.19965113065636
+          ]
+        ]
+      }
+    },
+    {
+      "id": 464,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Drumsö, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Drumsö",
+            "localadmin":"Helsingfors"
+          }
+        ]
+      }
+    },
+    {
+      "id": 465,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Hagalund, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Hagalund"
+          }
+        ]
+      }
+    },
+    {
+      "id": 466,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text":"Ängskulla, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Ängskulla",
+            "localadmin":"Esbo"
+          }
+        ],
+        "coordinates": [
+          [
+            24.76755060441069,
+            60.17096235682869
+          ]
+        ]
+      }
+    },
+    {
+      "id": 467,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Granö, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Granö",
+            "localadmin":"Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.863074044605057,
+            60.186370109408884
+          ]
+        ]
+      }
+    },
+    {
+      "id": 468,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Bredvik, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Bredvik",
+            "localadmin":"Esbo"
+          }
+        ]
+      }
+    },
+    {
+      "id": 469,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Kånala, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Kånala",
+            "localadmin":"Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.84706244991863,
+            60.23789598313317
+          ]
+        ]
+      }
+    },
+    {
+      "id": 470,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Haga, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Haga",
+            "localadmin":"Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.9017445665372,
+            60.22091252486491
+          ]
+        ]
+      }
+    },
+    {
+      "id": 471,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Gruvsta, Vanda"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Gruvsta",
+            "localadmin":"Vanda"
+          }
+        ],
+        "coordinates": [
+          [
+            24.870600487280043,
+            60.265739344798156
+          ]
+        ]
+      }
+    },
+    {
+      "id": 472,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Vandadalen, Vanda"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Vandadalen",
+            "localadmin":"Vanda"
+          }
+        ]
+      }
+    },
+    {
+      "id": 473,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Domargård, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Domargård",
+            "localadmin":"Helsingfors"
+          }
+        ]
+      }
+    },
+    {
+      "id": 474,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Bergans, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Bergans",
+            "localadmin":"Esbo"
+          }
+        ],
+        "coordinates": [
+          [
+            24.826788197168614,
+            60.214875156880325
+          ]
+        ]
+      }
+    },
+    {
+      "id": 475,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Boställsbacken, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Boställsbacken",
+            "localadmin":"Esbo"
+          }
+        ],
+        "coordinates": [
+          [
+            24.8244160220773,
+            60.22026642843532
+          ]
+        ]
+      }
+    },
+    {
+      "id": 476,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Lövö, Helsingfors"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Lövö",
+            "localadmin":"Helsingfors"
+          }
+        ],
+        "coordinates": [
+          [
+            24.850395954868105,
+            60.17840959489061
+          ]
+        ]
+      }
+    },
+    {
+      "id": 477,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Torvmossen, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name":"Torvmossen"
+          }
+        ],
+        "coordinates": [
+          [
+            24.781819580287326,
+            60.19755512327322
+          ]
+        ]
+      }
+    },
+    {
+      "id": 478,
+      "status": "pass",
+      "user": "hsldevcom",
+      "type": "acceptance",
+      "in": {
+        "text": "Tomtekulla, Esbo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Tomtekulla",
+            "localadmin":"Esbo"
+          }
+        ],
+        "coordinates": [
+          [
+            24.771819646486556,
+            60.17555114981213
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/test_cases/HelsinkiAddressTest.json
+++ b/test_cases/HelsinkiAddressTest.json
@@ -20,7 +20,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -42,7 +41,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -64,7 +62,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -86,7 +83,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -108,7 +104,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -130,7 +125,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -152,7 +146,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -174,7 +167,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -196,7 +188,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -218,7 +209,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -240,7 +230,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -262,7 +251,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -284,7 +272,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -306,7 +293,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -328,7 +314,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -350,7 +335,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -372,7 +356,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -394,7 +377,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -416,7 +398,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -438,7 +419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -460,7 +440,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -482,7 +461,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -504,7 +482,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -526,7 +503,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -548,7 +524,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -570,7 +545,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -592,7 +566,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -614,7 +587,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -636,7 +608,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -658,7 +629,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -680,7 +650,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -702,7 +671,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -724,7 +692,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -746,7 +713,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -768,7 +734,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -790,7 +755,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -812,7 +776,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -834,7 +797,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -856,7 +818,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -878,7 +839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -900,7 +860,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -922,7 +881,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -944,7 +902,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -966,7 +923,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -988,7 +944,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1010,7 +965,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1032,7 +986,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1054,7 +1007,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1076,7 +1028,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1098,7 +1049,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1120,7 +1070,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1142,7 +1091,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1164,7 +1112,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1186,7 +1133,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1208,7 +1154,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1230,7 +1175,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1252,7 +1196,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1274,7 +1217,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1296,7 +1238,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1318,7 +1259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1340,7 +1280,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1362,7 +1301,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1384,7 +1322,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1406,7 +1343,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1428,7 +1364,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1450,7 +1385,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -1472,7 +1406,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1494,7 +1427,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -1516,7 +1448,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1538,7 +1469,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -1560,7 +1490,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1582,7 +1511,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1604,7 +1532,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1626,7 +1553,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1648,7 +1574,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1670,7 +1595,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1692,7 +1616,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1714,7 +1637,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1736,7 +1658,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1758,7 +1679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1780,7 +1700,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -1802,7 +1721,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -1824,7 +1742,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1846,7 +1763,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1868,7 +1784,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1890,7 +1805,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1912,7 +1826,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1934,7 +1847,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1956,7 +1868,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1978,7 +1889,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2000,7 +1910,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2022,7 +1931,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2044,7 +1952,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2066,7 +1973,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2088,7 +1994,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2110,7 +2015,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2132,7 +2036,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2154,7 +2057,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2176,7 +2078,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2198,7 +2099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2220,7 +2120,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2242,7 +2141,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2264,7 +2162,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2286,7 +2183,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2308,7 +2204,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2330,7 +2225,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2352,7 +2246,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2374,7 +2267,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2396,7 +2288,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2418,7 +2309,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2440,7 +2330,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2462,7 +2351,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2484,7 +2372,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2506,7 +2393,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2528,7 +2414,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2550,7 +2435,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2572,7 +2456,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2594,7 +2477,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2616,7 +2498,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2638,7 +2519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2660,7 +2540,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2682,7 +2561,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2704,7 +2582,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2726,7 +2603,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2748,7 +2624,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2770,7 +2645,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2792,7 +2666,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2814,7 +2687,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2836,7 +2708,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2858,7 +2729,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2880,7 +2750,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2902,7 +2771,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2924,7 +2792,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2946,7 +2813,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2968,7 +2834,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2990,7 +2855,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3012,7 +2876,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3034,7 +2897,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3056,7 +2918,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3078,7 +2939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3100,7 +2960,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -3122,8 +2981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suolakivenkuja 1",
-            "localadmin": "Helsinki"
+            "name": "Suolakivenkuja 1"
           }
         ],
         "coordinates": [
@@ -3143,8 +3001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suomenniementie 13",
-            "localadmin": "Helsinki"
+            "name": "Suomenniementie 13"
           }
         ],
         "coordinates": [
@@ -3164,8 +3021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniemenranta 28",
-            "localadmin": "Helsinki"
+            "name": "Marjaniemenranta 28"
           }
         ],
         "coordinates": [
@@ -3185,8 +3041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniemenranta 33b",
-            "localadmin": "Helsinki"
+            "name": "Marjaniemenranta 33b"
           }
         ],
         "coordinates": [
@@ -3206,8 +3061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniemenranta 45a",
-            "localadmin": "Helsinki"
+            "name": "Marjaniemenranta 45a"
           }
         ],
         "coordinates": [
@@ -3227,8 +3081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehmustie 9b",
-            "localadmin": "Helsinki"
+            "name": "Lehmustie 9b"
           }
         ],
         "coordinates": [
@@ -3248,8 +3101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leikosaarenkuja 5",
-            "localadmin": "Helsinki"
+            "name": "Leikosaarenkuja 5"
           }
         ],
         "coordinates": [
@@ -3269,8 +3121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leikosaarentie 14",
-            "localadmin": "Helsinki"
+            "name": "Leikosaarentie 14"
           }
         ],
         "coordinates": [
@@ -3290,8 +3141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leikosaarentie 25",
-            "localadmin": "Helsinki"
+            "name": "Leikosaarentie 25"
           }
         ],
         "coordinates": [
@@ -3311,8 +3161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Louhikkotie 4",
-            "localadmin": "Helsinki"
+            "name": "Louhikkotie 4"
           }
         ],
         "coordinates": [
@@ -3332,8 +3181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lönnrotinkatu 1",
-            "localadmin": "Helsinki"
+            "name": "Lönnrotinkatu 1"
           }
         ],
         "coordinates": [
@@ -3353,8 +3201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maavallintie 25b",
-            "localadmin": "Helsinki"
+            "name": "Maavallintie 25b"
           }
         ],
         "coordinates": [
@@ -3374,8 +3221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laivurinkatu 13",
-            "localadmin": "Helsinki"
+            "name": "Laivurinkatu 13"
           }
         ],
         "coordinates": [
@@ -3395,8 +3241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lauttasaarentie 38",
-            "localadmin": "Helsinki"
+            "name": "Lauttasaarentie 38"
           }
         ],
         "coordinates": [
@@ -3416,8 +3261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Liuskekuja 2a",
-            "localadmin": "Helsinki"
+            "name": "Liuskekuja 2a"
           }
         ],
         "coordinates": [
@@ -3437,8 +3281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laulurastaanpolku 5",
-            "localadmin": "Helsinki"
+            "name": "Laulurastaanpolku 5"
           }
         ],
         "coordinates": [
@@ -3458,8 +3301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lohikallionranta 11",
-            "localadmin": "Helsinki"
+            "name": "Lohikallionranta 11"
           }
         ],
         "coordinates": [
@@ -3479,8 +3321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Louhenkuja 4",
-            "localadmin": "Helsinki"
+            "name": "Louhenkuja 4"
           }
         ],
         "coordinates": [
@@ -3500,8 +3341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Malmin Raitti 4",
-            "localadmin": "Helsinki"
+            "name": "Malmin Raitti 4"
           }
         ],
         "coordinates": [
@@ -3521,8 +3361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Limingantie 70",
-            "localadmin": "Helsinki"
+            "name": "Limingantie 70"
           }
         ],
         "coordinates": [
@@ -3542,8 +3381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Malmin Kauppatie 31",
-            "localadmin": "Helsinki"
+            "name": "Malmin Kauppatie 31"
           }
         ],
         "coordinates": [
@@ -3563,8 +3401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminkatu 28",
-            "localadmin": "Helsinki"
+            "name": "Malminkatu 28"
           }
         ],
         "coordinates": [
@@ -3584,8 +3421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminkatu 3",
-            "localadmin": "Helsinki"
+            "name": "Malminkatu 3"
           }
         ],
         "coordinates": [
@@ -3605,8 +3441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Läntinen Papinkatu 1",
-            "localadmin": "Helsinki"
+            "name": "Läntinen Papinkatu 1"
           }
         ],
         "coordinates": [
@@ -3626,8 +3461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maamiehenkuja 3",
-            "localadmin": "Helsinki"
+            "name": "Maamiehenkuja 3"
           }
         ],
         "coordinates": [
@@ -3647,8 +3481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maanmittarinpolku 2",
-            "localadmin": "Helsinki"
+            "name": "Maanmittarinpolku 2"
           }
         ],
         "coordinates": [
@@ -3668,8 +3501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Landbonpolku 7",
-            "localadmin": "Helsinki"
+            "name": "Landbonpolku 7"
           }
         ],
         "coordinates": [
@@ -3689,8 +3521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leipurintie 18",
-            "localadmin": "Helsinki"
+            "name": "Leipurintie 18"
           }
         ],
         "coordinates": [
@@ -3710,8 +3541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leivosenkuja 1",
-            "localadmin": "Helsinki"
+            "name": "Leivosenkuja 1"
           }
         ],
         "coordinates": [
@@ -3731,8 +3561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leivosentie 23b",
-            "localadmin": "Helsinki"
+            "name": "Leivosentie 23b"
           }
         ],
         "coordinates": [
@@ -3752,8 +3581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kravuntie 1",
-            "localadmin": "Helsinki"
+            "name": "Kravuntie 1"
           }
         ],
         "coordinates": [
@@ -3773,8 +3601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kristianinkatu 19",
-            "localadmin": "Helsinki"
+            "name": "Kristianinkatu 19"
           }
         ],
         "coordinates": [
@@ -3794,8 +3621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotipolku 12",
-            "localadmin": "Helsinki"
+            "name": "Kotipolku 12"
           }
         ],
         "coordinates": [
@@ -3815,8 +3641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotisaarenkatu 12",
-            "localadmin": "Helsinki"
+            "name": "Kotisaarenkatu 12"
           }
         ],
         "coordinates": [
@@ -3836,8 +3661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotitie 22",
-            "localadmin": "Helsinki"
+            "name": "Kotitie 22"
           }
         ],
         "coordinates": [
@@ -3857,8 +3681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurkimoisio 2b",
-            "localadmin": "Helsinki"
+            "name": "Kurkimoisio 2b"
           }
         ],
         "coordinates": [
@@ -3878,8 +3701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kustaankatu 5",
-            "localadmin": "Helsinki"
+            "name": "Kustaankatu 5"
           }
         ],
         "coordinates": [
@@ -3899,8 +3721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Käenkuja 8",
-            "localadmin": "Helsinki"
+            "name": "Käenkuja 8"
           }
         ],
         "coordinates": [
@@ -3920,8 +3741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuismakuja 2",
-            "localadmin": "Helsinki"
+            "name": "Kuismakuja 2"
           }
         ],
         "coordinates": [
@@ -3941,8 +3761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylätie 8",
-            "localadmin": "Helsinki"
+            "name": "Kylätie 8"
           }
         ],
         "coordinates": [
@@ -3962,8 +3781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivikkotie 17",
-            "localadmin": "Helsinki"
+            "name": "Koivikkotie 17"
           }
         ],
         "coordinates": [
@@ -3983,8 +3801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koudantie 7",
-            "localadmin": "Helsinki"
+            "name": "Koudantie 7"
           }
         ],
         "coordinates": [
@@ -4004,8 +3821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylvöpolku 3",
-            "localadmin": "Helsinki"
+            "name": "Kylvöpolku 3"
           }
         ],
         "coordinates": [
@@ -4025,8 +3841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laajasuontie 2",
-            "localadmin": "Helsinki"
+            "name": "Laajasuontie 2"
           }
         ],
         "coordinates": [
@@ -4046,8 +3861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuulijantie 17",
-            "localadmin": "Helsinki"
+            "name": "Kuulijantie 17"
           }
         ],
         "coordinates": [
@@ -4067,8 +3881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksotie 17",
-            "localadmin": "Helsinki"
+            "name": "Laaksotie 17"
           }
         ],
         "coordinates": [
@@ -4088,8 +3901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Korkeakoskenkuja 4",
-            "localadmin": "Helsinki"
+            "name": "Korkeakoskenkuja 4"
           }
         ],
         "coordinates": [
@@ -4109,8 +3921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Korkeanmäentie 7",
-            "localadmin": "Helsinki"
+            "name": "Korkeanmäentie 7"
           }
         ],
         "coordinates": [
@@ -4130,8 +3941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotikaivontie 2",
-            "localadmin": "Helsinki"
+            "name": "Kotikaivontie 2"
           }
         ],
         "coordinates": [
@@ -4151,8 +3961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyösti Kallion Tie 10",
-            "localadmin": "Helsinki"
+            "name": "Kyösti Kallion Tie 10"
           }
         ],
         "coordinates": [
@@ -4172,8 +3981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kummeltie 10",
-            "localadmin": "Helsinki"
+            "name": "Kummeltie 10"
           }
         ],
         "coordinates": [
@@ -4193,8 +4001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyläsaarenkuja 2",
-            "localadmin": "Helsinki"
+            "name": "Kyläsaarenkuja 2"
           }
         ],
         "coordinates": [
@@ -4214,8 +4021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kymintie 77",
-            "localadmin": "Helsinki"
+            "name": "Kymintie 77"
           }
         ],
         "coordinates": [
@@ -4235,8 +4041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyläkirkontie 13",
-            "localadmin": "Helsinki"
+            "name": "Kyläkirkontie 13"
           }
         ],
         "coordinates": [
@@ -4256,8 +4061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyläkunnantie 38a",
-            "localadmin": "Helsinki"
+            "name": "Kyläkunnantie 38a"
           }
         ],
         "coordinates": [
@@ -4277,8 +4081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Klamintie 17",
-            "localadmin": "Helsinki"
+            "name": "Klamintie 17"
           }
         ],
         "coordinates": [
@@ -4298,8 +4101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotasuontie 6",
-            "localadmin": "Helsinki"
+            "name": "Kotasuontie 6"
           }
         ],
         "coordinates": [
@@ -4319,8 +4121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulutuvantie 17b",
-            "localadmin": "Helsinki"
+            "name": "Koulutuvantie 17b"
           }
         ],
         "coordinates": [
@@ -4340,8 +4141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksotie 6",
-            "localadmin": "Helsinki"
+            "name": "Laaksotie 6"
           }
         ],
         "coordinates": [
@@ -4361,8 +4161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ladonlukonpolku 16b",
-            "localadmin": "Helsinki"
+            "name": "Ladonlukonpolku 16b"
           }
         ],
         "coordinates": [
@@ -4382,8 +4181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotinummentie 24b",
-            "localadmin": "Helsinki"
+            "name": "Kotinummentie 24b"
           }
         ],
         "coordinates": [
@@ -4403,8 +4201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotikonnuntie 20",
-            "localadmin": "Helsinki"
+            "name": "Kotikonnuntie 20"
           }
         ],
         "coordinates": [
@@ -4424,8 +4221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusiniementie 25",
-            "localadmin": "Helsinki"
+            "name": "Kuusiniementie 25"
           }
         ],
         "coordinates": [
@@ -4445,8 +4241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kölitie 6",
-            "localadmin": "Helsinki"
+            "name": "Kölitie 6"
           }
         ],
         "coordinates": [
@@ -4466,8 +4261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kytkintie 5",
-            "localadmin": "Helsinki"
+            "name": "Kytkintie 5"
           }
         ],
         "coordinates": [
@@ -4487,8 +4281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Köysikuja 10",
-            "localadmin": "Helsinki"
+            "name": "Köysikuja 10"
           }
         ],
         "coordinates": [
@@ -4508,8 +4301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Oraspolku 8a",
-            "localadmin": "Helsinki"
+            "name": "Oraspolku 8a"
           }
         ],
         "coordinates": [
@@ -4529,8 +4321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Oravatie 20",
-            "localadmin": "Helsinki"
+            "name": "Oravatie 20"
           }
         ],
         "coordinates": [
@@ -4550,8 +4341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puuskaniementie 27",
-            "localadmin": "Helsinki"
+            "name": "Puuskaniementie 27"
           }
         ],
         "coordinates": [
@@ -4571,8 +4361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mehiläistie 26",
-            "localadmin": "Helsinki"
+            "name": "Mehiläistie 26"
           }
         ],
         "coordinates": [
@@ -4592,8 +4381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paloheinäntie 64",
-            "localadmin": "Helsinki"
+            "name": "Paloheinäntie 64"
           }
         ],
         "coordinates": [
@@ -4613,8 +4401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihkatie 6",
-            "localadmin": "Helsinki"
+            "name": "Pihkatie 6"
           }
         ],
         "coordinates": [
@@ -4634,8 +4421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pienen Villasaaren Tie 6",
-            "localadmin": "Helsinki"
+            "name": "Pienen Villasaaren Tie 6"
           }
         ],
         "coordinates": [
@@ -4655,8 +4441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puustellinpolku 15",
-            "localadmin": "Helsinki"
+            "name": "Puustellinpolku 15"
           }
         ],
         "coordinates": [
@@ -4676,8 +4461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Niittyluhdantie 7",
-            "localadmin": "Helsinki"
+            "name": "Niittyluhdantie 7"
           }
         ],
         "coordinates": [
@@ -4697,8 +4481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osuuskunnantie 26",
-            "localadmin": "Helsinki"
+            "name": "Osuuskunnantie 26"
           }
         ],
         "coordinates": [
@@ -4718,8 +4501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puusuutarintie 1",
-            "localadmin": "Helsinki"
+            "name": "Puusuutarintie 1"
           }
         ],
         "coordinates": [
@@ -4739,8 +4521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ormusrinne 4",
-            "localadmin": "Helsinki"
+            "name": "Ormusrinne 4"
           }
         ],
         "coordinates": [
@@ -4760,8 +4541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Porthaninkatu 7",
-            "localadmin": "Helsinki"
+            "name": "Porthaninkatu 7"
           }
         ],
         "coordinates": [
@@ -4781,8 +4561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Palomäentie 5",
-            "localadmin": "Helsinki"
+            "name": "Palomäentie 5"
           }
         ],
         "coordinates": [
@@ -4802,8 +4581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maunulanmäki 2",
-            "localadmin": "Helsinki"
+            "name": "Maunulanmäki 2"
           }
         ],
         "coordinates": [
@@ -4823,8 +4601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Piennar 3",
-            "localadmin": "Helsinki"
+            "name": "Piennar 3"
           }
         ],
         "coordinates": [
@@ -4844,8 +4621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pietarinkatu 20",
-            "localadmin": "Helsinki"
+            "name": "Pietarinkatu 20"
           }
         ],
         "coordinates": [
@@ -4865,8 +4641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjoinen Makasiinikatu 2",
-            "localadmin": "Helsinki"
+            "name": "Pohjoinen Makasiinikatu 2"
           }
         ],
         "coordinates": [
@@ -4886,8 +4661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjoisranta 22",
-            "localadmin": "Helsinki"
+            "name": "Pohjoisranta 22"
           }
         ],
         "coordinates": [
@@ -4907,8 +4681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puunkaatajantie 18a",
-            "localadmin": "Helsinki"
+            "name": "Puunkaatajantie 18a"
           }
         ],
         "coordinates": [
@@ -4928,8 +4701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puunkaatajantie 27b",
-            "localadmin": "Helsinki"
+            "name": "Puunkaatajantie 27b"
           }
         ],
         "coordinates": [
@@ -4949,8 +4721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Onnentie 16",
-            "localadmin": "Helsinki"
+            "name": "Onnentie 16"
           }
         ],
         "coordinates": [
@@ -4970,8 +4741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Oppipojankuja 30",
-            "localadmin": "Helsinki"
+            "name": "Oppipojankuja 30"
           }
         ],
         "coordinates": [
@@ -4991,8 +4761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mechelininkatu 21",
-            "localadmin": "Helsinki"
+            "name": "Mechelininkatu 21"
           }
         ],
         "coordinates": [
@@ -5012,8 +4781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Purjetuulenkuja 8",
-            "localadmin": "Helsinki"
+            "name": "Purjetuulenkuja 8"
           }
         ],
         "coordinates": [
@@ -5033,8 +4801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pamppulankuja 6",
-            "localadmin": "Helsinki"
+            "name": "Pamppulankuja 6"
           }
         ],
         "coordinates": [
@@ -5054,8 +4821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paneliantie 11b",
-            "localadmin": "Helsinki"
+            "name": "Paneliantie 11b"
           }
         ],
         "coordinates": [
@@ -5075,8 +4841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paneliantie 2",
-            "localadmin": "Helsinki"
+            "name": "Paneliantie 2"
           }
         ],
         "coordinates": [
@@ -5096,8 +4861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nilsiänkatu 8",
-            "localadmin": "Helsinki"
+            "name": "Nilsiänkatu 8"
           }
         ],
         "coordinates": [
@@ -5117,8 +4881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perustie 38",
-            "localadmin": "Helsinki"
+            "name": "Perustie 38"
           }
         ],
         "coordinates": [
@@ -5138,8 +4901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perämiehenkatu 10",
-            "localadmin": "Helsinki"
+            "name": "Perämiehenkatu 10"
           }
         ],
         "coordinates": [
@@ -5159,8 +4921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Petaksentie 28",
-            "localadmin": "Helsinki"
+            "name": "Petaksentie 28"
           }
         ],
         "coordinates": [
@@ -5180,8 +4941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjolankatu 6",
-            "localadmin": "Helsinki"
+            "name": "Pohjolankatu 6"
           }
         ],
         "coordinates": [
@@ -5201,8 +4961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Omenamäenkatu 27",
-            "localadmin": "Helsinki"
+            "name": "Omenamäenkatu 27"
           }
         ],
         "coordinates": [
@@ -5222,8 +4981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ojamäentie 6",
-            "localadmin": "Helsinki"
+            "name": "Ojamäentie 6"
           }
         ],
         "coordinates": [
@@ -5243,8 +5001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ollilantie 22",
-            "localadmin": "Helsinki"
+            "name": "Ollilantie 22"
           }
         ],
         "coordinates": [
@@ -5264,8 +5021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Latokartanontori 7",
-            "localadmin": "Helsinki"
+            "name": "Latokartanontori 7"
           }
         ],
         "coordinates": [
@@ -5285,8 +5041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Liiketie 24",
-            "localadmin": "Helsinki"
+            "name": "Liiketie 24"
           }
         ],
         "coordinates": [
@@ -5306,8 +5061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Liiketie 27",
-            "localadmin": "Helsinki"
+            "name": "Liiketie 27"
           }
         ],
         "coordinates": [
@@ -5327,8 +5081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osuuskunnantie 45",
-            "localadmin": "Helsinki"
+            "name": "Osuuskunnantie 45"
           }
         ],
         "coordinates": [
@@ -5348,8 +5101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pajuniityntie 8",
-            "localadmin": "Helsinki"
+            "name": "Pajuniityntie 8"
           }
         ],
         "coordinates": [
@@ -5369,8 +5121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osuuskunnantie 94",
-            "localadmin": "Helsinki"
+            "name": "Osuuskunnantie 94"
           }
         ],
         "coordinates": [
@@ -5390,8 +5141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsäpurontie 11",
-            "localadmin": "Helsinki"
+            "name": "Metsäpurontie 11"
           }
         ],
         "coordinates": [
@@ -5411,8 +5161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Omenamäenkatu 6",
-            "localadmin": "Helsinki"
+            "name": "Omenamäenkatu 6"
           }
         ],
         "coordinates": [
@@ -5432,8 +5181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lähdeniityntie 7b",
-            "localadmin": "Helsinki"
+            "name": "Lähdeniityntie 7b"
           }
         ],
         "coordinates": [
@@ -5453,8 +5201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mesenaatinpolku 3",
-            "localadmin": "Helsinki"
+            "name": "Mesenaatinpolku 3"
           }
         ],
         "coordinates": [
@@ -5474,8 +5221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mikael Soinisen Tie 8",
-            "localadmin": "Helsinki"
+            "name": "Mikael Soinisen Tie 8"
           }
         ],
         "coordinates": [
@@ -5495,8 +5241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Naulapolku 3",
-            "localadmin": "Helsinki"
+            "name": "Naulapolku 3"
           }
         ],
         "coordinates": [
@@ -5516,8 +5261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkitorpantie 37",
-            "localadmin": "Helsinki"
+            "name": "Mäkitorpantie 37"
           }
         ],
         "coordinates": [
@@ -5537,8 +5281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Muuttolinnuntie 14",
-            "localadmin": "Helsinki"
+            "name": "Muuttolinnuntie 14"
           }
         ],
         "coordinates": [
@@ -5558,8 +5301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäenalus 19",
-            "localadmin": "Helsinki"
+            "name": "Mäenalus 19"
           }
         ],
         "coordinates": [
@@ -5579,8 +5321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nummikuja 6",
-            "localadmin": "Helsinki"
+            "name": "Nummikuja 6"
           }
         ],
         "coordinates": [
@@ -5600,8 +5341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Norkkokuja 5",
-            "localadmin": "Helsinki"
+            "name": "Norkkokuja 5"
           }
         ],
         "coordinates": [
@@ -5621,8 +5361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lielahdentie 7a",
-            "localadmin": "Helsinki"
+            "name": "Lielahdentie 7a"
           }
         ],
         "coordinates": [
@@ -5642,8 +5381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Liikkalantie 18a",
-            "localadmin": "Helsinki"
+            "name": "Liikkalantie 18a"
           }
         ],
         "coordinates": [
@@ -5663,8 +5401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lupajantie 4",
-            "localadmin": "Helsinki"
+            "name": "Lupajantie 4"
           }
         ],
         "coordinates": [
@@ -5684,8 +5421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Otto Brandtin Tie 21",
-            "localadmin": "Helsinki"
+            "name": "Otto Brandtin Tie 21"
           }
         ],
         "coordinates": [
@@ -5705,8 +5441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Merikapteenintie 49",
-            "localadmin": "Helsinki"
+            "name": "Merikapteenintie 49"
           }
         ],
         "coordinates": [
@@ -5726,8 +5461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Naapurintie 2",
-            "localadmin": "Helsinki"
+            "name": "Naapurintie 2"
           }
         ],
         "coordinates": [
@@ -5747,8 +5481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nallenmäenrinne 2",
-            "localadmin": "Helsinki"
+            "name": "Nallenmäenrinne 2"
           }
         ],
         "coordinates": [
@@ -5768,8 +5501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkitorpantie 11",
-            "localadmin": "Helsinki"
+            "name": "Mäkitorpantie 11"
           }
         ],
         "coordinates": [
@@ -5789,8 +5521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkitorpantie 23",
-            "localadmin": "Helsinki"
+            "name": "Mäkitorpantie 23"
           }
         ],
         "coordinates": [
@@ -5810,8 +5541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Latokartanonkaari 48",
-            "localadmin": "Helsinki"
+            "name": "Latokartanonkaari 48"
           }
         ],
         "coordinates": [
@@ -5831,8 +5561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lappeentie 24",
-            "localadmin": "Helsinki"
+            "name": "Lappeentie 24"
           }
         ],
         "coordinates": [
@@ -5852,8 +5581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nousiaistentie 1",
-            "localadmin": "Helsinki"
+            "name": "Nousiaistentie 1"
           }
         ],
         "coordinates": [
@@ -5873,8 +5601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ohjaskuja 8",
-            "localadmin": "Helsinki"
+            "name": "Ohjaskuja 8"
           }
         ],
         "coordinates": [
@@ -5894,8 +5621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paciuksenkaari 9",
-            "localadmin": "Helsinki"
+            "name": "Paciuksenkaari 9"
           }
         ],
         "coordinates": [
@@ -5915,8 +5641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenhuilunpolku 3",
-            "localadmin": "Helsinki"
+            "name": "Paimenhuilunpolku 3"
           }
         ],
         "coordinates": [
@@ -5936,8 +5661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenhuilunpolku 7",
-            "localadmin": "Helsinki"
+            "name": "Paimenhuilunpolku 7"
           }
         ],
         "coordinates": [
@@ -5957,8 +5681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Paahtajankuja 4",
-            "localadmin": "Helsinki"
+            "name": "Paahtajankuja 4"
           }
         ],
         "coordinates": [
@@ -5978,8 +5701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Meritullinkatu 14",
-            "localadmin": "Helsinki"
+            "name": "Meritullinkatu 14"
           }
         ],
         "coordinates": [
@@ -5999,8 +5721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rukkilantie 4",
-            "localadmin": "Helsinki"
+            "name": "Rukkilantie 4"
           }
         ],
         "coordinates": [
@@ -6020,8 +5741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rohkatie 2",
-            "localadmin": "Helsinki"
+            "name": "Rohkatie 2"
           }
         ],
         "coordinates": [
@@ -6041,8 +5761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Roihuvuorentie 4",
-            "localadmin": "Helsinki"
+            "name": "Roihuvuorentie 4"
           }
         ],
         "coordinates": [
@@ -6062,8 +5781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sahaajankatu 16",
-            "localadmin": "Helsinki"
+            "name": "Sahaajankatu 16"
           }
         ],
         "coordinates": [
@@ -6083,8 +5801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saramäentie 28b",
-            "localadmin": "Helsinki"
+            "name": "Saramäentie 28b"
           }
         ],
         "coordinates": [
@@ -6104,8 +5821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raitamäentie 26",
-            "localadmin": "Helsinki"
+            "name": "Raitamäentie 26"
           }
         ],
         "coordinates": [
@@ -6125,8 +5841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raitamäentie 27a",
-            "localadmin": "Helsinki"
+            "name": "Raitamäentie 27a"
           }
         ],
         "coordinates": [
@@ -6146,8 +5861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rusthollinpolku 3",
-            "localadmin": "Helsinki"
+            "name": "Rusthollinpolku 3"
           }
         ],
         "coordinates": [
@@ -6167,8 +5881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruukinlahdentie 4",
-            "localadmin": "Helsinki"
+            "name": "Ruukinlahdentie 4"
           }
         ],
         "coordinates": [
@@ -6188,8 +5901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ratamestarinkatu 11",
-            "localadmin": "Helsinki"
+            "name": "Ratamestarinkatu 11"
           }
         ],
         "coordinates": [
@@ -6209,8 +5921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ratamestarinkatu 8",
-            "localadmin": "Helsinki"
+            "name": "Ratamestarinkatu 8"
           }
         ],
         "coordinates": [
@@ -6230,8 +5941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Roomankuja 2",
-            "localadmin": "Helsinki"
+            "name": "Roomankuja 2"
           }
         ],
         "coordinates": [
@@ -6251,8 +5961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Reijolankatu 3",
-            "localadmin": "Helsinki"
+            "name": "Reijolankatu 3"
           }
         ],
         "coordinates": [
@@ -6272,8 +5981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saramäentie 32a",
-            "localadmin": "Helsinki"
+            "name": "Saramäentie 32a"
           }
         ],
         "coordinates": [
@@ -6293,8 +6001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rudolfinkuja 2b",
-            "localadmin": "Helsinki"
+            "name": "Rudolfinkuja 2b"
           }
         ],
         "coordinates": [
@@ -6314,8 +6021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rehbinderintie 7",
-            "localadmin": "Helsinki"
+            "name": "Rehbinderintie 7"
           }
         ],
         "coordinates": [
@@ -6335,8 +6041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ripusuontie 100",
-            "localadmin": "Helsinki"
+            "name": "Ripusuontie 100"
           }
         ],
         "coordinates": [
@@ -6356,8 +6061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ripusuontie 33",
-            "localadmin": "Helsinki"
+            "name": "Ripusuontie 33"
           }
         ],
         "coordinates": [
@@ -6377,8 +6081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saarnaajantie 33",
-            "localadmin": "Helsinki"
+            "name": "Saarnaajantie 33"
           }
         ],
         "coordinates": [
@@ -6398,8 +6101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saavipolku 1",
-            "localadmin": "Helsinki"
+            "name": "Saavipolku 1"
           }
         ],
         "coordinates": [
@@ -6419,8 +6121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saavipolku 6",
-            "localadmin": "Helsinki"
+            "name": "Saavipolku 6"
           }
         ],
         "coordinates": [
@@ -6440,8 +6141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänpalauksenpolku 2",
-            "localadmin": "Helsinki"
+            "name": "Päivänpalauksenpolku 2"
           }
         ],
         "coordinates": [
@@ -6461,8 +6161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sateenkaarentie 39",
-            "localadmin": "Helsinki"
+            "name": "Sateenkaarentie 39"
           }
         ],
         "coordinates": [
@@ -6482,8 +6181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ranckenintie 13",
-            "localadmin": "Helsinki"
+            "name": "Ranckenintie 13"
           }
         ],
         "coordinates": [
@@ -6503,8 +6201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ripusuontie 47",
-            "localadmin": "Helsinki"
+            "name": "Ripusuontie 47"
           }
         ],
         "coordinates": [
@@ -6524,8 +6221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Risto Rytin Tie 16",
-            "localadmin": "Helsinki"
+            "name": "Risto Rytin Tie 16"
           }
         ],
         "coordinates": [
@@ -6545,8 +6241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rohkatie 12",
-            "localadmin": "Helsinki"
+            "name": "Rohkatie 12"
           }
         ],
         "coordinates": [
@@ -6566,8 +6261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sahatie 16b",
-            "localadmin": "Helsinki"
+            "name": "Sahatie 16b"
           }
         ],
         "coordinates": [
@@ -6587,8 +6281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raidepolku 4a",
-            "localadmin": "Helsinki"
+            "name": "Raidepolku 4a"
           }
         ],
         "coordinates": [
@@ -6608,8 +6301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Renvallinkuja 3",
-            "localadmin": "Helsinki"
+            "name": "Renvallinkuja 3"
           }
         ],
         "coordinates": [
@@ -6629,8 +6321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rasavilliuksenkuja 7",
-            "localadmin": "Helsinki"
+            "name": "Rasavilliuksenkuja 7"
           }
         ],
         "coordinates": [
@@ -6650,8 +6341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sarpapolku 3",
-            "localadmin": "Helsinki"
+            "name": "Sarpapolku 3"
           }
         ],
         "coordinates": [
@@ -6671,8 +6361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rakennusmestarintie 14b",
-            "localadmin": "Helsinki"
+            "name": "Rakennusmestarintie 14b"
           }
         ],
         "coordinates": [
@@ -6692,8 +6381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peitsipolku 2",
-            "localadmin": "Helsinki"
+            "name": "Peitsipolku 2"
           }
         ],
         "coordinates": [
@@ -6713,8 +6401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjanpellontie 10",
-            "localadmin": "Helsinki"
+            "name": "Pohjanpellontie 10"
           }
         ],
         "coordinates": [
@@ -6734,8 +6421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puotilan Metrotori 2",
-            "localadmin": "Helsinki"
+            "name": "Puotilan Metrotori 2"
           }
         ],
         "coordinates": [
@@ -6755,8 +6441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rikalantie 13",
-            "localadmin": "Helsinki"
+            "name": "Rikalantie 13"
           }
         ],
         "coordinates": [
@@ -6776,8 +6461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puistokaari 1",
-            "localadmin": "Helsinki"
+            "name": "Puistokaari 1"
           }
         ],
         "coordinates": [
@@ -6797,8 +6481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruotutorpantie 15",
-            "localadmin": "Helsinki"
+            "name": "Ruotutorpantie 15"
           }
         ],
         "coordinates": [
@@ -6818,8 +6501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Prikitie 5",
-            "localadmin": "Helsinki"
+            "name": "Prikitie 5"
           }
         ],
         "coordinates": [
@@ -6839,8 +6521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ranckeninpolku 2",
-            "localadmin": "Helsinki"
+            "name": "Ranckeninpolku 2"
           }
         ],
         "coordinates": [
@@ -6860,8 +6541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pellavakaskentie 14a",
-            "localadmin": "Helsinki"
+            "name": "Pellavakaskentie 14a"
           }
         ],
         "coordinates": [
@@ -6881,8 +6561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjoinen Hesperiankatu 22",
-            "localadmin": "Helsinki"
+            "name": "Pohjoinen Hesperiankatu 22"
           }
         ],
         "coordinates": [
@@ -6902,8 +6581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjantähdentie 24",
-            "localadmin": "Helsinki"
+            "name": "Pohjantähdentie 24"
           }
         ],
         "coordinates": [
@@ -6923,8 +6601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Punapaadenkuja 4",
-            "localadmin": "Helsinki"
+            "name": "Punapaadenkuja 4"
           }
         ],
         "coordinates": [
@@ -6944,8 +6621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajistonkuja 7",
-            "localadmin": "Helsinki"
+            "name": "Pihlajistonkuja 7"
           }
         ],
         "coordinates": [
@@ -6965,8 +6641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakilantie 101b",
-            "localadmin": "Helsinki"
+            "name": "Pakilantie 101b"
           }
         ],
         "coordinates": [
@@ -6986,8 +6661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkänsillanranta 11",
-            "localadmin": "Helsinki"
+            "name": "Pitkänsillanranta 11"
           }
         ],
         "coordinates": [
@@ -7007,8 +6681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Parivaljakontie 6",
-            "localadmin": "Helsinki"
+            "name": "Parivaljakontie 6"
           }
         ],
         "coordinates": [
@@ -7028,8 +6701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitäjänmäentie 13",
-            "localadmin": "Helsinki"
+            "name": "Pitäjänmäentie 13"
           }
         ],
         "coordinates": [
@@ -7049,8 +6721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Piikintie 6",
-            "localadmin": "Helsinki"
+            "name": "Piikintie 6"
           }
         ],
         "coordinates": [
@@ -7070,8 +6741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pirkkolantie 11",
-            "localadmin": "Helsinki"
+            "name": "Pirkkolantie 11"
           }
         ],
         "coordinates": [
@@ -7091,8 +6761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Puistolan Raitti 16b",
-            "localadmin": "Helsinki"
+            "name": "Puistolan Raitti 16b"
           }
         ],
         "coordinates": [
@@ -7112,8 +6781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pukinmäenaukio 2",
-            "localadmin": "Helsinki"
+            "name": "Pukinmäenaukio 2"
           }
         ],
         "coordinates": [
@@ -7133,8 +6801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakkaajankatu 2",
-            "localadmin": "Helsinki"
+            "name": "Pakkaajankatu 2"
           }
         ],
         "coordinates": [
@@ -7154,8 +6821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Porttikuja 3",
-            "localadmin": "Helsinki"
+            "name": "Porttikuja 3"
           }
         ],
         "coordinates": [
@@ -7175,8 +6841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Palikkapolku 2",
-            "localadmin": "Helsinki"
+            "name": "Palikkapolku 2"
           }
         ],
         "coordinates": [
@@ -7196,8 +6861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peiponkatu 4",
-            "localadmin": "Helsinki"
+            "name": "Peiponkatu 4"
           }
         ],
         "coordinates": [
@@ -7217,8 +6881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sariolantie 10",
-            "localadmin": "Helsinki"
+            "name": "Sariolantie 10"
           }
         ],
         "coordinates": [
@@ -7238,8 +6901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vesakkotie 6",
-            "localadmin": "Helsinki"
+            "name": "Vesakkotie 6"
           }
         ],
         "coordinates": [
@@ -7259,8 +6921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suntionpolku 8",
-            "localadmin": "Helsinki"
+            "name": "Suntionpolku 8"
           }
         ],
         "coordinates": [
@@ -7280,8 +6941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavetti Laitisen Katu 3",
-            "localadmin": "Helsinki"
+            "name": "Taavetti Laitisen Katu 3"
           }
         ],
         "coordinates": [
@@ -7301,8 +6961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Veräjämäenpolku 4",
-            "localadmin": "Helsinki"
+            "name": "Veräjämäenpolku 4"
           }
         ],
         "coordinates": [
@@ -7322,8 +6981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaakamestarinpolku 4",
-            "localadmin": "Helsinki"
+            "name": "Vaakamestarinpolku 4"
           }
         ],
         "coordinates": [
@@ -7343,8 +7001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenkaupungintie 6",
-            "localadmin": "Helsinki"
+            "name": "Uudenkaupungintie 6"
           }
         ],
         "coordinates": [
@@ -7364,8 +7021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Talvitie 1",
-            "localadmin": "Helsinki"
+            "name": "Vanha Talvitie 1"
           }
         ],
         "coordinates": [
@@ -7385,8 +7041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenmaankatu 41",
-            "localadmin": "Helsinki"
+            "name": "Uudenmaankatu 41"
           }
         ],
         "coordinates": [
@@ -7406,8 +7061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Valuraudantie 7",
-            "localadmin": "Helsinki"
+            "name": "Valuraudantie 7"
           }
         ],
         "coordinates": [
@@ -7427,8 +7081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanajantie 20",
-            "localadmin": "Helsinki"
+            "name": "Vanajantie 20"
           }
         ],
         "coordinates": [
@@ -7448,8 +7101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Valssiparinkuja 1",
-            "localadmin": "Helsinki"
+            "name": "Valssiparinkuja 1"
           }
         ],
         "coordinates": [
@@ -7469,8 +7121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaskipellontie 14",
-            "localadmin": "Helsinki"
+            "name": "Vaskipellontie 14"
           }
         ],
         "coordinates": [
@@ -7490,8 +7141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vesalantie 67",
-            "localadmin": "Helsinki"
+            "name": "Vesalantie 67"
           }
         ],
         "coordinates": [
@@ -7511,8 +7161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Turkhaudantie 5",
-            "localadmin": "Helsinki"
+            "name": "Turkhaudantie 5"
           }
         ],
         "coordinates": [
@@ -7532,8 +7181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulvaniityntie 4",
-            "localadmin": "Helsinki"
+            "name": "Tulvaniityntie 4"
           }
         ],
         "coordinates": [
@@ -7553,8 +7201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Takilatie 4",
-            "localadmin": "Helsinki"
+            "name": "Takilatie 4"
           }
         ],
         "coordinates": [
@@ -7574,8 +7221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuohikoivuntie 2",
-            "localadmin": "Helsinki"
+            "name": "Tuohikoivuntie 2"
           }
         ],
         "coordinates": [
@@ -7595,8 +7241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Turkismiehenkuja 3",
-            "localadmin": "Helsinki"
+            "name": "Turkismiehenkuja 3"
           }
         ],
         "coordinates": [
@@ -7616,8 +7261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavetinkuja 6",
-            "localadmin": "Helsinki"
+            "name": "Taavetinkuja 6"
           }
         ],
         "coordinates": [
@@ -7637,8 +7281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tavaststjernankatu 11",
-            "localadmin": "Helsinki"
+            "name": "Tavaststjernankatu 11"
           }
         ],
         "coordinates": [
@@ -7658,8 +7301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Turvekuja 8",
-            "localadmin": "Helsinki"
+            "name": "Turvekuja 8"
           }
         ],
         "coordinates": [
@@ -7679,8 +7321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tasaisenpellontie 13",
-            "localadmin": "Helsinki"
+            "name": "Tasaisenpellontie 13"
           }
         ],
         "coordinates": [
@@ -7700,8 +7341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Untamalantie 8",
-            "localadmin": "Helsinki"
+            "name": "Untamalantie 8"
           }
         ],
         "coordinates": [
@@ -7721,8 +7361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Hämeenkyläntie 20",
-            "localadmin": "Helsinki"
+            "name": "Vanha Hämeenkyläntie 20"
           }
         ],
         "coordinates": [
@@ -7742,8 +7381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Hämeenkyläntie 25",
-            "localadmin": "Helsinki"
+            "name": "Vanha Hämeenkyläntie 25"
           }
         ],
         "coordinates": [
@@ -7763,8 +7401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Silkkikuja 1",
-            "localadmin": "Helsinki"
+            "name": "Silkkikuja 1"
           }
         ],
         "coordinates": [
@@ -7784,8 +7421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Untamontie 8",
-            "localadmin": "Helsinki"
+            "name": "Untamontie 8"
           }
         ],
         "coordinates": [
@@ -7805,8 +7441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallirinne 3",
-            "localadmin": "Helsinki"
+            "name": "Vallirinne 3"
           }
         ],
         "coordinates": [
@@ -7826,8 +7461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Venlanpolku 2",
-            "localadmin": "Helsinki"
+            "name": "Venlanpolku 2"
           }
         ],
         "coordinates": [
@@ -7847,8 +7481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Venttiilikuja 2",
-            "localadmin": "Helsinki"
+            "name": "Venttiilikuja 2"
           }
         ],
         "coordinates": [
@@ -7868,8 +7501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sturenkatu 21",
-            "localadmin": "Helsinki"
+            "name": "Sturenkatu 21"
           }
         ],
         "coordinates": [
@@ -7889,8 +7521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Särkkä F 1",
-            "localadmin": "Helsinki"
+            "name": "Särkkä F 1"
           }
         ],
         "coordinates": [
@@ -7910,8 +7541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säynäslahdentie 3",
-            "localadmin": "Helsinki"
+            "name": "Säynäslahdentie 3"
           }
         ],
         "coordinates": [
@@ -7931,8 +7561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuhkimontie 7",
-            "localadmin": "Helsinki"
+            "name": "Tuhkimontie 7"
           }
         ],
         "coordinates": [
@@ -7952,8 +7581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Untuvaisentie 11",
-            "localadmin": "Helsinki"
+            "name": "Untuvaisentie 11"
           }
         ],
         "coordinates": [
@@ -7973,8 +7601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sunilanpolku 3a",
-            "localadmin": "Helsinki"
+            "name": "Sunilanpolku 3a"
           }
         ],
         "coordinates": [
@@ -7994,8 +7621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Valuraudantie 2",
-            "localadmin": "Helsinki"
+            "name": "Valuraudantie 2"
           }
         ],
         "coordinates": [
@@ -8015,8 +7641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vellamonkatu 15",
-            "localadmin": "Helsinki"
+            "name": "Vellamonkatu 15"
           }
         ],
         "coordinates": [
@@ -8036,8 +7661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Takametsäntie 12",
-            "localadmin": "Helsinki"
+            "name": "Takametsäntie 12"
           }
         ],
         "coordinates": [
@@ -8057,8 +7681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säterintie 12",
-            "localadmin": "Helsinki"
+            "name": "Säterintie 12"
           }
         ],
         "coordinates": [
@@ -8078,8 +7701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sirkkalanmäki 4a",
-            "localadmin": "Helsinki"
+            "name": "Sirkkalanmäki 4a"
           }
         ],
         "coordinates": [
@@ -8099,8 +7721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Stansvikin Uusikylä 31",
-            "localadmin": "Helsinki"
+            "name": "Stansvikin Uusikylä 31"
           }
         ],
         "coordinates": [
@@ -8120,8 +7741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sirkkalanpolku 3",
-            "localadmin": "Helsinki"
+            "name": "Sirkkalanpolku 3"
           }
         ],
         "coordinates": [
@@ -8141,8 +7761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Svanströmintie 12b",
-            "localadmin": "Helsinki"
+            "name": "Svanströmintie 12b"
           }
         ],
         "coordinates": [
@@ -8162,8 +7781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammisalontie 9",
-            "localadmin": "Helsinki"
+            "name": "Tammisalontie 9"
           }
         ],
         "coordinates": [
@@ -8183,8 +7801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Susisaari B 21",
-            "localadmin": "Helsinki"
+            "name": "Susisaari B 21"
           }
         ],
         "coordinates": [
@@ -8204,8 +7821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammitie 6",
-            "localadmin": "Helsinki"
+            "name": "Tammitie 6"
           }
         ],
         "coordinates": [
@@ -8225,8 +7841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Teuvo Pakkalan Tie 7",
-            "localadmin": "Helsinki"
+            "name": "Teuvo Pakkalan Tie 7"
           }
         ],
         "coordinates": [
@@ -8246,8 +7861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Seurasaarentie 11",
-            "localadmin": "Helsinki"
+            "name": "Seurasaarentie 11"
           }
         ],
         "coordinates": [
@@ -8267,8 +7881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Simeonintie 5",
-            "localadmin": "Helsinki"
+            "name": "Simeonintie 5"
           }
         ],
         "coordinates": [
@@ -8288,8 +7901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiilimäki 18",
-            "localadmin": "Helsinki"
+            "name": "Tiilimäki 18"
           }
         ],
         "coordinates": [
@@ -8309,8 +7921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sormuspolku 14",
-            "localadmin": "Helsinki"
+            "name": "Sormuspolku 14"
           }
         ],
         "coordinates": [
@@ -8330,8 +7941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sarvastonkaari 1a",
-            "localadmin": "Helsinki"
+            "name": "Sarvastonkaari 1a"
           }
         ],
         "coordinates": [
@@ -8351,8 +7961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Terrintie 10",
-            "localadmin": "Helsinki"
+            "name": "Terrintie 10"
           }
         ],
         "coordinates": [
@@ -8372,8 +7981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Solnantie 13",
-            "localadmin": "Helsinki"
+            "name": "Solnantie 13"
           }
         ],
         "coordinates": [
@@ -8393,8 +8001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sädetie 9",
-            "localadmin": "Helsinki"
+            "name": "Sädetie 9"
           }
         ],
         "coordinates": [
@@ -8414,8 +8021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sähköttäjänkatu 1",
-            "localadmin": "Helsinki"
+            "name": "Sähköttäjänkatu 1"
           }
         ],
         "coordinates": [
@@ -8435,8 +8041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Susisaari B 52",
-            "localadmin": "Helsinki"
+            "name": "Susisaari B 52"
           }
         ],
         "coordinates": [
@@ -8456,8 +8061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Susisaari B 53",
-            "localadmin": "Helsinki"
+            "name": "Susisaari B 53"
           }
         ],
         "coordinates": [
@@ -8477,8 +8081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tanotorventie 51a",
-            "localadmin": "Helsinki"
+            "name": "Tanotorventie 51a"
           }
         ],
         "coordinates": [
@@ -8498,8 +8101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sienikuja 2",
-            "localadmin": "Helsinki"
+            "name": "Sienikuja 2"
           }
         ],
         "coordinates": [
@@ -8519,8 +8121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sihteerintie 3",
-            "localadmin": "Helsinki"
+            "name": "Sihteerintie 3"
           }
         ],
         "coordinates": [
@@ -8540,8 +8141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siilitie 11a",
-            "localadmin": "Helsinki"
+            "name": "Siilitie 11a"
           }
         ],
         "coordinates": [
@@ -8561,8 +8161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Talitiaistie 18",
-            "localadmin": "Helsinki"
+            "name": "Talitiaistie 18"
           }
         ],
         "coordinates": [
@@ -8582,8 +8181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tenholantie 12",
-            "localadmin": "Helsinki"
+            "name": "Tenholantie 12"
           }
         ],
         "coordinates": [
@@ -8603,8 +8201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tenhonkuja 6",
-            "localadmin": "Helsinki"
+            "name": "Tenhonkuja 6"
           }
         ],
         "coordinates": [
@@ -8624,8 +8221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sopulitie 1a",
-            "localadmin": "Helsinki"
+            "name": "Sopulitie 1a"
           }
         ],
         "coordinates": [
@@ -8645,8 +8241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sopulitie 8",
-            "localadmin": "Helsinki"
+            "name": "Sopulitie 8"
           }
         ],
         "coordinates": [
@@ -8666,8 +8261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorolantie 11a",
-            "localadmin": "Helsinki"
+            "name": "Sorolantie 11a"
           }
         ],
         "coordinates": [
@@ -8687,8 +8281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Teljokuja 2",
-            "localadmin": "Helsinki"
+            "name": "Teljokuja 2"
           }
         ],
         "coordinates": [
@@ -8708,8 +8301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sirkkalanmäki 34",
-            "localadmin": "Helsinki"
+            "name": "Sirkkalanmäki 34"
           }
         ],
         "coordinates": [
@@ -8729,8 +8321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sysimiehenpolku 7a",
-            "localadmin": "Helsinki"
+            "name": "Sysimiehenpolku 7a"
           }
         ],
         "coordinates": [
@@ -8750,8 +8341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tapperinkuja 3a",
-            "localadmin": "Helsinki"
+            "name": "Tapperinkuja 3a"
           }
         ],
         "coordinates": [
@@ -8771,8 +8361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suopellonkaari 15",
-            "localadmin": "Helsinki"
+            "name": "Suopellonkaari 15"
           }
         ],
         "coordinates": [
@@ -8792,8 +8381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siimakuja 12",
-            "localadmin": "Helsinki"
+            "name": "Siimakuja 12"
           }
         ],
         "coordinates": [
@@ -8813,8 +8401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siltasaarenkatu 13",
-            "localadmin": "Helsinki"
+            "name": "Siltasaarenkatu 13"
           }
         ],
         "coordinates": [
@@ -8834,8 +8421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Veturitie 3",
-            "localadmin": "Helsinki"
+            "name": "Veturitie 3"
           }
         ],
         "coordinates": [
@@ -8855,8 +8441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viitankruununtie 30",
-            "localadmin": "Helsinki"
+            "name": "Viitankruununtie 30"
           }
         ],
         "coordinates": [
@@ -8876,8 +8461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaskisalmenkuja 8",
-            "localadmin": "Helsinki"
+            "name": "Vaskisalmenkuja 8"
           }
         ],
         "coordinates": [
@@ -8897,8 +8481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viittapolku 5b",
-            "localadmin": "Helsinki"
+            "name": "Viittapolku 5b"
           }
         ],
         "coordinates": [
@@ -8918,8 +8501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähäntuvantie 11",
-            "localadmin": "Helsinki"
+            "name": "Vähäntuvantie 11"
           }
         ],
         "coordinates": [
@@ -8939,8 +8521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallilan Siirtolapuutarha (Puisto Tai Kenttä) 74",
-            "localadmin": "Helsinki"
+            "name": "Vallilan Siirtolapuutarha (Puisto Tai Kenttä) 74"
           }
         ],
         "coordinates": [
@@ -8960,8 +8541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vilppulantie 26g",
-            "localadmin": "Helsinki"
+            "name": "Vilppulantie 26g"
           }
         ],
         "coordinates": [
@@ -8981,8 +8561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vihdintie 19",
-            "localadmin": "Helsinki"
+            "name": "Vihdintie 19"
           }
         ],
         "coordinates": [
@@ -9002,8 +8581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vilsandinkuja 7",
-            "localadmin": "Helsinki"
+            "name": "Vilsandinkuja 7"
           }
         ],
         "coordinates": [
@@ -9023,8 +8601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuorimiehenkatu 29",
-            "localadmin": "Helsinki"
+            "name": "Vuorimiehenkatu 29"
           }
         ],
         "coordinates": [
@@ -9044,8 +8621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Topiaksenpolku 1",
-            "localadmin": "Helsinki"
+            "name": "Topiaksenpolku 1"
           }
         ],
         "coordinates": [
@@ -9065,8 +8641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Topiaksentie 12b",
-            "localadmin": "Helsinki"
+            "name": "Topiaksentie 12b"
           }
         ],
         "coordinates": [
@@ -9086,8 +8661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viilarintie 5",
-            "localadmin": "Helsinki"
+            "name": "Viilarintie 5"
           }
         ],
         "coordinates": [
@@ -9107,8 +8681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viinenkuja 7",
-            "localadmin": "Helsinki"
+            "name": "Viinenkuja 7"
           }
         ],
         "coordinates": [
@@ -9128,8 +8701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viinentie 5",
-            "localadmin": "Helsinki"
+            "name": "Viinentie 5"
           }
         ],
         "coordinates": [
@@ -9149,8 +8721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yrjönkatu 6",
-            "localadmin": "Helsinki"
+            "name": "Yrjönkatu 6"
           }
         ],
         "coordinates": [
@@ -9170,8 +8741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yrttimaantie 18",
-            "localadmin": "Helsinki"
+            "name": "Yrttimaantie 18"
           }
         ],
         "coordinates": [
@@ -9191,8 +8761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viulupolku 5",
-            "localadmin": "Helsinki"
+            "name": "Viulupolku 5"
           }
         ],
         "coordinates": [
@@ -9212,8 +8781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallesmannintie 54",
-            "localadmin": "Helsinki"
+            "name": "Vallesmannintie 54"
           }
         ],
         "coordinates": [
@@ -9233,8 +8801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallesmannintie 5b",
-            "localadmin": "Helsinki"
+            "name": "Vallesmannintie 5b"
           }
         ],
         "coordinates": [
@@ -9254,8 +8821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Von Daehnin Katu 16",
-            "localadmin": "Helsinki"
+            "name": "Von Daehnin Katu 16"
           }
         ],
         "coordinates": [
@@ -9275,8 +8841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vainiotie 20b",
-            "localadmin": "Helsinki"
+            "name": "Vainiotie 20b"
           }
         ],
         "coordinates": [
@@ -9296,8 +8861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vattuniemenkuja 1",
-            "localadmin": "Helsinki"
+            "name": "Vattuniemenkuja 1"
           }
         ],
         "coordinates": [
@@ -9317,8 +8881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yrttimaantie 4",
-            "localadmin": "Helsinki"
+            "name": "Yrttimaantie 4"
           }
         ],
         "coordinates": [
@@ -9338,8 +8901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Äestäjäntie 22",
-            "localadmin": "Helsinki"
+            "name": "Äestäjäntie 22"
           }
         ],
         "coordinates": [
@@ -9359,8 +8921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulvaniitynkuja 1",
-            "localadmin": "Helsinki"
+            "name": "Tulvaniitynkuja 1"
           }
         ],
         "coordinates": [
@@ -9380,8 +8941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Von Daehnin Katu 22",
-            "localadmin": "Helsinki"
+            "name": "Von Daehnin Katu 22"
           }
         ],
         "coordinates": [
@@ -9401,8 +8961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Työmiehenkatu 9",
-            "localadmin": "Helsinki"
+            "name": "Työmiehenkatu 9"
           }
         ],
         "coordinates": [
@@ -9422,8 +8981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallilan Siirtolapuutarha (Puisto Tai Kenttä) 1",
-            "localadmin": "Helsinki"
+            "name": "Vallilan Siirtolapuutarha (Puisto Tai Kenttä) 1"
           }
         ],
         "coordinates": [
@@ -9443,8 +9001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Voudintie 2",
-            "localadmin": "Helsinki"
+            "name": "Voudintie 2"
           }
         ],
         "coordinates": [
@@ -9464,8 +9021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vilkenintie 3",
-            "localadmin": "Helsinki"
+            "name": "Vilkenintie 3"
           }
         ],
         "coordinates": [
@@ -9485,8 +9041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ässänrinne 10",
-            "localadmin": "Helsinki"
+            "name": "Ässänrinne 10"
           }
         ],
         "coordinates": [
@@ -9506,8 +9061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yliopistonkatu 2",
-            "localadmin": "Helsinki"
+            "name": "Yliopistonkatu 2"
           }
         ],
         "coordinates": [
@@ -9527,8 +9081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuorilinnakkeentie 22",
-            "localadmin": "Helsinki"
+            "name": "Vuorilinnakkeentie 22"
           }
         ],
         "coordinates": [
@@ -9548,8 +9101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vannetie 53a",
-            "localadmin": "Helsinki"
+            "name": "Vannetie 53a"
           }
         ],
         "coordinates": [
@@ -9569,8 +9121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Trumpettikuja 4",
-            "localadmin": "Helsinki"
+            "name": "Trumpettikuja 4"
           }
         ],
         "coordinates": [
@@ -9590,8 +9141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viljelijäntie 10",
-            "localadmin": "Helsinki"
+            "name": "Viljelijäntie 10"
           }
         ],
         "coordinates": [
@@ -9611,8 +9161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuorilinnakkeentie 6a",
-            "localadmin": "Helsinki"
+            "name": "Vuorilinnakkeentie 6a"
           }
         ],
         "coordinates": [
@@ -9632,8 +9181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vienankatu 30",
-            "localadmin": "Helsinki"
+            "name": "Vienankatu 30"
           }
         ],
         "coordinates": [
@@ -9653,8 +9201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vienantori 3",
-            "localadmin": "Helsinki"
+            "name": "Vienantori 3"
           }
         ],
         "coordinates": [
@@ -9674,8 +9221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Topeliuksenkatu 16",
-            "localadmin": "Helsinki"
+            "name": "Topeliuksenkatu 16"
           }
         ],
         "coordinates": [
@@ -9695,8 +9241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uiskotie 42",
-            "localadmin": "Helsinki"
+            "name": "Uiskotie 42"
           }
         ],
         "coordinates": [
@@ -9716,8 +9261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuosaarentie 1b",
-            "localadmin": "Helsinki"
+            "name": "Vuosaarentie 1b"
           }
         ],
         "coordinates": [
@@ -9737,8 +9281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Traverssikuja 5",
-            "localadmin": "Helsinki"
+            "name": "Traverssikuja 5"
           }
         ],
         "coordinates": [
@@ -9758,8 +9301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Klemetintie 14",
-            "localadmin": "Vantaa"
+            "name": "Klemetintie 14"
           }
         ],
         "coordinates": [
@@ -9779,8 +9321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tankomäenkatu 18",
-            "localadmin": "Helsinki"
+            "name": "Tankomäenkatu 18"
           }
         ],
         "coordinates": [
@@ -9800,8 +9341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tankomäenkatu 7",
-            "localadmin": "Helsinki"
+            "name": "Tankomäenkatu 7"
           }
         ],
         "coordinates": [
@@ -9821,8 +9361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ison-Antintie 11b",
-            "localadmin": "Helsinki"
+            "name": "Ison-Antintie 11b"
           }
         ],
         "coordinates": [
@@ -9842,8 +9381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koirasaarentie 27",
-            "localadmin": "Helsinki"
+            "name": "Koirasaarentie 27"
           }
         ],
         "coordinates": [
@@ -9863,8 +9401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ullantie 25",
-            "localadmin": "Vantaa"
+            "name": "Ullantie 25"
           }
         ],
         "coordinates": [
@@ -9884,8 +9421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ainonkuja 5",
-            "localadmin": "Vantaa"
+            "name": "Ainonkuja 5"
           }
         ],
         "coordinates": [
@@ -9905,8 +9441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Aatelikuja 4",
-            "localadmin": "Vantaa"
+            "name": "Aatelikuja 4"
           }
         ],
         "coordinates": [
@@ -9926,8 +9461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ajolenkki 10",
-            "localadmin": "Vantaa"
+            "name": "Ajolenkki 10"
           }
         ],
         "coordinates": [
@@ -9947,8 +9481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Akanapolku 1",
-            "localadmin": "Vantaa"
+            "name": "Akanapolku 1"
           }
         ],
         "coordinates": [
@@ -9968,8 +9501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Akatemiantie 4",
-            "localadmin": "Vantaa"
+            "name": "Akatemiantie 4"
           }
         ],
         "coordinates": [
@@ -9989,8 +9521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Annankallionpolku 1",
-            "localadmin": "Vantaa"
+            "name": "Annankallionpolku 1"
           }
         ],
         "coordinates": [
@@ -10010,8 +9541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Annankalliontie 2b",
-            "localadmin": "Vantaa"
+            "name": "Annankalliontie 2b"
           }
         ],
         "coordinates": [
@@ -10031,8 +9561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Apollokuja 3",
-            "localadmin": "Vantaa"
+            "name": "Apollokuja 3"
           }
         ],
         "coordinates": [
@@ -10052,8 +9581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Arjantie 14",
-            "localadmin": "Vantaa"
+            "name": "Arjantie 14"
           }
         ],
         "coordinates": [
@@ -10073,8 +9601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Artturintie 5",
-            "localadmin": "Vantaa"
+            "name": "Artturintie 5"
           }
         ],
         "coordinates": [
@@ -10094,8 +9621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Auertie 11",
-            "localadmin": "Vantaa"
+            "name": "Auertie 11"
           }
         ],
         "coordinates": [
@@ -10115,8 +9641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Asterintie 12b",
-            "localadmin": "Vantaa"
+            "name": "Asterintie 12b"
           }
         ],
         "coordinates": [
@@ -10136,8 +9661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Estetie 8b",
-            "localadmin": "Vantaa"
+            "name": "Estetie 8b"
           }
         ],
         "coordinates": [
@@ -10157,8 +9681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Haapalantie 14",
-            "localadmin": "Vantaa"
+            "name": "Haapalantie 14"
           }
         ],
         "coordinates": [
@@ -10178,8 +9701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Haapatie 25",
-            "localadmin": "Vantaa"
+            "name": "Haapatie 25"
           }
         ],
         "coordinates": [
@@ -10199,8 +9721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Haapanatie 12",
-            "localadmin": "Vantaa"
+            "name": "Haapanatie 12"
           }
         ],
         "coordinates": [
@@ -10220,8 +9741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakapolku 2",
-            "localadmin": "Vantaa"
+            "name": "Hakapolku 2"
           }
         ],
         "coordinates": [
@@ -10241,8 +9761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakunilantie 48",
-            "localadmin": "Vantaa"
+            "name": "Hakunilantie 48"
           }
         ],
         "coordinates": [
@@ -10262,8 +9781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakunilantie 52",
-            "localadmin": "Vantaa"
+            "name": "Hakunilantie 52"
           }
         ],
         "coordinates": [
@@ -10283,8 +9801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakintie 3",
-            "localadmin": "Vantaa"
+            "name": "Hakintie 3"
           }
         ],
         "coordinates": [
@@ -10304,8 +9821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakunilantie 79",
-            "localadmin": "Vantaa"
+            "name": "Hakunilantie 79"
           }
         ],
         "coordinates": [
@@ -10325,8 +9841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Harjurinne 18",
-            "localadmin": "Vantaa"
+            "name": "Harjurinne 18"
           }
         ],
         "coordinates": [
@@ -10346,8 +9861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Harjutie 3a",
-            "localadmin": "Vantaa"
+            "name": "Harjutie 3a"
           }
         ],
         "coordinates": [
@@ -10367,8 +9881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Harjutie 27",
-            "localadmin": "Vantaa"
+            "name": "Harjutie 27"
           }
         ],
         "coordinates": [
@@ -10388,8 +9901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Helenankuja 14",
-            "localadmin": "Vantaa"
+            "name": "Helenankuja 14"
           }
         ],
         "coordinates": [
@@ -10409,8 +9921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hellevintie 20a",
-            "localadmin": "Vantaa"
+            "name": "Hellevintie 20a"
           }
         ],
         "coordinates": [
@@ -10430,8 +9941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Heporinne 3",
-            "localadmin": "Vantaa"
+            "name": "Heporinne 3"
           }
         ],
         "coordinates": [
@@ -10451,8 +9961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Herttuantie 1",
-            "localadmin": "Vantaa"
+            "name": "Herttuantie 1"
           }
         ],
         "coordinates": [
@@ -10472,8 +9981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hevonojantie 8",
-            "localadmin": "Vantaa"
+            "name": "Hevonojantie 8"
           }
         ],
         "coordinates": [
@@ -10493,8 +10001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hevoshaantie 15",
-            "localadmin": "Vantaa"
+            "name": "Hevoshaantie 15"
           }
         ],
         "coordinates": [
@@ -10514,8 +10021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hevoshaantie 18",
-            "localadmin": "Vantaa"
+            "name": "Hevoshaantie 18"
           }
         ],
         "coordinates": [
@@ -10535,8 +10041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirvitie 8b",
-            "localadmin": "Vantaa"
+            "name": "Hirvitie 8b"
           }
         ],
         "coordinates": [
@@ -10556,8 +10061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirvitie 19a",
-            "localadmin": "Vantaa"
+            "name": "Hirvitie 19a"
           }
         ],
         "coordinates": [
@@ -10577,8 +10081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Honkatie 15b",
-            "localadmin": "Vantaa"
+            "name": "Honkatie 15b"
           }
         ],
         "coordinates": [
@@ -10598,8 +10101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Honkatie 19",
-            "localadmin": "Vantaa"
+            "name": "Honkatie 19"
           }
         ],
         "coordinates": [
@@ -10619,8 +10121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Honkamäentie 13",
-            "localadmin": "Vantaa"
+            "name": "Honkamäentie 13"
           }
         ],
         "coordinates": [
@@ -10640,8 +10141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Honkanummentie 1",
-            "localadmin": "Vantaa"
+            "name": "Honkanummentie 1"
           }
         ],
         "coordinates": [
@@ -10661,8 +10161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Huovintie 20",
-            "localadmin": "Vantaa"
+            "name": "Huovintie 20"
           }
         ],
         "coordinates": [
@@ -10682,8 +10181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hukantie 3b",
-            "localadmin": "Vantaa"
+            "name": "Hukantie 3b"
           }
         ],
         "coordinates": [
@@ -10703,8 +10201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hyljekuja 2",
-            "localadmin": "Vantaa"
+            "name": "Hyljekuja 2"
           }
         ],
         "coordinates": [
@@ -10724,8 +10221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Häkilätie 8",
-            "localadmin": "Vantaa"
+            "name": "Häkilätie 8"
           }
         ],
         "coordinates": [
@@ -10745,8 +10241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ilponkuja 6",
-            "localadmin": "Vantaa"
+            "name": "Ilponkuja 6"
           }
         ],
         "coordinates": [
@@ -10766,8 +10261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Irmelintie 10b",
-            "localadmin": "Vantaa"
+            "name": "Irmelintie 10b"
           }
         ],
         "coordinates": [
@@ -10787,8 +10281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ismontie 4",
-            "localadmin": "Vantaa"
+            "name": "Ismontie 4"
           }
         ],
         "coordinates": [
@@ -10808,8 +10301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Isonmännyntie 41a",
-            "localadmin": "Vantaa"
+            "name": "Isonmännyntie 41a"
           }
         ],
         "coordinates": [
@@ -10829,8 +10321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Itäinen Valkoisenlähteentie 17",
-            "localadmin": "Vantaa"
+            "name": "Itäinen Valkoisenlähteentie 17"
           }
         ],
         "coordinates": [
@@ -10850,8 +10341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Jokiniementie 58",
-            "localadmin": "Vantaa"
+            "name": "Jokiniementie 58"
           }
         ],
         "coordinates": [
@@ -10871,8 +10361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Aisatie 26b",
-            "localadmin": "Vantaa"
+            "name": "Aisatie 26b"
           }
         ],
         "coordinates": [
@@ -10892,8 +10381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Bredantie 9",
-            "localadmin": "Kauniainen"
+            "name": "Bredantie 9"
           }
         ],
         "coordinates": [
@@ -10913,8 +10401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Jondalintie 12",
-            "localadmin": "Kauniainen"
+            "name": "Jondalintie 12"
           }
         ],
         "coordinates": [
@@ -10934,8 +10421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Eteläinen Heikelintie 5",
-            "localadmin": "Kauniainen"
+            "name": "Eteläinen Heikelintie 5"
           }
         ],
         "coordinates": [
@@ -10955,8 +10441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Helsingintie 22",
-            "localadmin": "Kauniainen"
+            "name": "Helsingintie 22"
           }
         ],
         "coordinates": [
@@ -10976,8 +10461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylpyläntie 11a",
-            "localadmin": "Kauniainen"
+            "name": "Kylpyläntie 11a"
           }
         ],
         "coordinates": [
@@ -10997,8 +10481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maisterintie 20",
-            "localadmin": "Kauniainen"
+            "name": "Maisterintie 20"
           }
         ],
         "coordinates": [
@@ -11018,8 +10501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntymäenkuja 4",
-            "localadmin": "Kauniainen"
+            "name": "Mäntymäenkuja 4"
           }
         ],
         "coordinates": [
@@ -11039,8 +10521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjoinen Heikelintie 20",
-            "localadmin": "Kauniainen"
+            "name": "Pohjoinen Heikelintie 20"
           }
         ],
         "coordinates": [
@@ -11060,8 +10541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Turuntienportti 9",
-            "localadmin": "Kauniainen"
+            "name": "Turuntienportti 9"
           }
         ],
         "coordinates": [
@@ -11081,8 +10561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Stenbergintie 23b",
-            "localadmin": "Kauniainen"
+            "name": "Stenbergintie 23b"
           }
         ],
         "coordinates": [
@@ -11102,8 +10581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Stockmannintie 3",
-            "localadmin": "Kauniainen"
+            "name": "Stockmannintie 3"
           }
         ],
         "coordinates": [
@@ -11123,8 +10601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Urheilutie 2",
-            "localadmin": "Kauniainen"
+            "name": "Urheilutie 2"
           }
         ],
         "coordinates": [
@@ -11144,8 +10621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yhtiöntie 26",
-            "localadmin": "Kauniainen"
+            "name": "Yhtiöntie 26"
           }
         ],
         "coordinates": [
@@ -11165,8 +10641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Jousitie 8c",
-            "localadmin": "Vantaa"
+            "name": "Jousitie 8c"
           }
         ],
         "coordinates": [
@@ -11186,8 +10661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Aittarivi 4",
-            "localadmin": "Vantaa"
+            "name": "Aittarivi 4"
           }
         ],
         "coordinates": [
@@ -11207,8 +10681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Juolukkakuja 4",
-            "localadmin": "Vantaa"
+            "name": "Juolukkakuja 4"
           }
         ],
         "coordinates": [
@@ -11228,8 +10701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Jänöpolku 9",
-            "localadmin": "Vantaa"
+            "name": "Jänöpolku 9"
           }
         ],
         "coordinates": [
@@ -11249,8 +10721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaakkoisväylä 2",
-            "localadmin": "Vantaa"
+            "name": "Kaakkoisväylä 2"
           }
         ],
         "coordinates": [
@@ -11270,8 +10741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaarlonkuja 4",
-            "localadmin": "Vantaa"
+            "name": "Kaarlonkuja 4"
           }
         ],
         "coordinates": [
@@ -11291,8 +10761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaarnapolku 5a",
-            "localadmin": "Vantaa"
+            "name": "Kaarnapolku 5a"
           }
         ],
         "coordinates": [
@@ -11312,8 +10781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaavintie 19",
-            "localadmin": "Vantaa"
+            "name": "Kaavintie 19"
           }
         ],
         "coordinates": [
@@ -11333,8 +10801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaivostie 3",
-            "localadmin": "Vantaa"
+            "name": "Kaivostie 3"
           }
         ],
         "coordinates": [
@@ -11354,8 +10821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalliokuja 3",
-            "localadmin": "Vantaa"
+            "name": "Kalliokuja 3"
           }
         ],
         "coordinates": [
@@ -11375,8 +10841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalpakuja 4",
-            "localadmin": "Vantaa"
+            "name": "Kalpakuja 4"
           }
         ],
         "coordinates": [
@@ -11396,8 +10861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kankaankuja 1",
-            "localadmin": "Vantaa"
+            "name": "Kankaankuja 1"
           }
         ],
         "coordinates": [
@@ -11417,8 +10881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kankurintie 11a",
-            "localadmin": "Vantaa"
+            "name": "Kankurintie 11a"
           }
         ],
         "coordinates": [
@@ -11438,8 +10901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kankurintie 12a",
-            "localadmin": "Vantaa"
+            "name": "Kankurintie 12a"
           }
         ],
         "coordinates": [
@@ -11459,8 +10921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kappalaisentie 8",
-            "localadmin": "Vantaa"
+            "name": "Kappalaisentie 8"
           }
         ],
         "coordinates": [
@@ -11480,8 +10941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karpaattienkuja 15",
-            "localadmin": "Vantaa"
+            "name": "Karpaattienkuja 15"
           }
         ],
         "coordinates": [
@@ -11501,8 +10961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhunkierros 2e",
-            "localadmin": "Vantaa"
+            "name": "Karhunkierros 2e"
           }
         ],
         "coordinates": [
@@ -11522,8 +10981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karvalaukunkuja 5",
-            "localadmin": "Vantaa"
+            "name": "Karvalaukunkuja 5"
           }
         ],
         "coordinates": [
@@ -11543,8 +11001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Katriinantie 44",
-            "localadmin": "Vantaa"
+            "name": "Katriinantie 44"
           }
         ],
         "coordinates": [
@@ -11564,8 +11021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Katriinantie 54",
-            "localadmin": "Vantaa"
+            "name": "Katriinantie 54"
           }
         ],
         "coordinates": [
@@ -11585,8 +11041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaskelankuja 6",
-            "localadmin": "Vantaa"
+            "name": "Kaskelankuja 6"
           }
         ],
         "coordinates": [
@@ -11606,8 +11061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Katrinkuja 4",
-            "localadmin": "Vantaa"
+            "name": "Katrinkuja 4"
           }
         ],
         "coordinates": [
@@ -11627,8 +11081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaunispolku 16",
-            "localadmin": "Vantaa"
+            "name": "Kaunispolku 16"
           }
         ],
         "coordinates": [
@@ -11648,8 +11101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaunisharju 22b",
-            "localadmin": "Vantaa"
+            "name": "Kaunisharju 22b"
           }
         ],
         "coordinates": [
@@ -11669,8 +11121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehruukuja 16c",
-            "localadmin": "Vantaa"
+            "name": "Kehruukuja 16c"
           }
         ],
         "coordinates": [
@@ -11690,8 +11141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehruukuja 18b",
-            "localadmin": "Vantaa"
+            "name": "Kehruukuja 18b"
           }
         ],
         "coordinates": [
@@ -11711,8 +11161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehävuorenkuja 12a",
-            "localadmin": "Vantaa"
+            "name": "Kehävuorenkuja 12a"
           }
         ],
         "coordinates": [
@@ -11732,8 +11181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehruukuja 2c",
-            "localadmin": "Vantaa"
+            "name": "Kehruukuja 2c"
           }
         ],
         "coordinates": [
@@ -11753,8 +11201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kellokkaantie 1",
-            "localadmin": "Vantaa"
+            "name": "Kellokkaantie 1"
           }
         ],
         "coordinates": [
@@ -11774,8 +11221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Keikarinkuja 3",
-            "localadmin": "Vantaa"
+            "name": "Keikarinkuja 3"
           }
         ],
         "coordinates": [
@@ -11795,8 +11241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Keilapolku 2",
-            "localadmin": "Vantaa"
+            "name": "Keilapolku 2"
           }
         ],
         "coordinates": [
@@ -11816,8 +11261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Keltasirkunkuja 6",
-            "localadmin": "Vantaa"
+            "name": "Keltasirkunkuja 6"
           }
         ],
         "coordinates": [
@@ -11837,8 +11281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Keltavuokontie 4",
-            "localadmin": "Vantaa"
+            "name": "Keltavuokontie 4"
           }
         ],
         "coordinates": [
@@ -11858,8 +11301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Keskustie 10",
-            "localadmin": "Vantaa"
+            "name": "Keskustie 10"
           }
         ],
         "coordinates": [
@@ -11879,8 +11321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kerkkätie 3",
-            "localadmin": "Vantaa"
+            "name": "Kerkkätie 3"
           }
         ],
         "coordinates": [
@@ -11900,8 +11341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiertomäenkuja 3a",
-            "localadmin": "Vantaa"
+            "name": "Kiertomäenkuja 3a"
           }
         ],
         "coordinates": [
@@ -11921,8 +11361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiertomäentie 11c",
-            "localadmin": "Vantaa"
+            "name": "Kiertomäentie 11c"
           }
         ],
         "coordinates": [
@@ -11942,8 +11381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilterinrinne 8",
-            "localadmin": "Vantaa"
+            "name": "Kilterinrinne 8"
           }
         ],
         "coordinates": [
@@ -11963,8 +11401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilterintie 12",
-            "localadmin": "Vantaa"
+            "name": "Kilterintie 12"
           }
         ],
         "coordinates": [
@@ -11984,8 +11421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kimaratie 1",
-            "localadmin": "Vantaa"
+            "name": "Kimaratie 1"
           }
         ],
         "coordinates": [
@@ -12005,8 +11441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiilletie 15a",
-            "localadmin": "Vantaa"
+            "name": "Kiilletie 15a"
           }
         ],
         "coordinates": [
@@ -12026,8 +11461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirkkotie 35b",
-            "localadmin": "Vantaa"
+            "name": "Kirkkotie 35b"
           }
         ],
         "coordinates": [
@@ -12047,8 +11481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirkkotie 37a",
-            "localadmin": "Vantaa"
+            "name": "Kirkkotie 37a"
           }
         ],
         "coordinates": [
@@ -12068,8 +11501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivimäenkuja 1",
-            "localadmin": "Vantaa"
+            "name": "Kivimäenkuja 1"
           }
         ],
         "coordinates": [
@@ -12089,8 +11521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiskotie 14",
-            "localadmin": "Vantaa"
+            "name": "Kiskotie 14"
           }
         ],
         "coordinates": [
@@ -12110,8 +11541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivuhaantie 7",
-            "localadmin": "Vantaa"
+            "name": "Koivuhaantie 7"
           }
         ],
         "coordinates": [
@@ -12131,8 +11561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivukummunkuja 3",
-            "localadmin": "Vantaa"
+            "name": "Koivukummunkuja 3"
           }
         ],
         "coordinates": [
@@ -12152,8 +11581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivurinne 7a",
-            "localadmin": "Vantaa"
+            "name": "Koivurinne 7a"
           }
         ],
         "coordinates": [
@@ -12173,8 +11601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivumäenrinne 16",
-            "localadmin": "Vantaa"
+            "name": "Koivumäenrinne 16"
           }
         ],
         "coordinates": [
@@ -12194,8 +11621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kongontie 30",
-            "localadmin": "Vantaa"
+            "name": "Kongontie 30"
           }
         ],
         "coordinates": [
@@ -12215,8 +11641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kontiokuja 6a",
-            "localadmin": "Vantaa"
+            "name": "Kontiokuja 6a"
           }
         ],
         "coordinates": [
@@ -12236,8 +11661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmikallionrinne 2",
-            "localadmin": "Vantaa"
+            "name": "Kolmikallionrinne 2"
           }
         ],
         "coordinates": [
@@ -12257,8 +11681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koskelotie 19a",
-            "localadmin": "Vantaa"
+            "name": "Koskelotie 19a"
           }
         ],
         "coordinates": [
@@ -12278,8 +11701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotkansiipi 2",
-            "localadmin": "Vantaa"
+            "name": "Kotkansiipi 2"
           }
         ],
         "coordinates": [
@@ -12299,8 +11721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulutie 35a",
-            "localadmin": "Vantaa"
+            "name": "Koulutie 35a"
           }
         ],
         "coordinates": [
@@ -12320,8 +11741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulutie 49",
-            "localadmin": "Vantaa"
+            "name": "Koulutie 49"
           }
         ],
         "coordinates": [
@@ -12341,8 +11761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kreivinkuja 2",
-            "localadmin": "Vantaa"
+            "name": "Kreivinkuja 2"
           }
         ],
         "coordinates": [
@@ -12362,8 +11781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukantie 5",
-            "localadmin": "Vantaa"
+            "name": "Kukantie 5"
           }
         ],
         "coordinates": [
@@ -12383,8 +11801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kulokukonkuja 2",
-            "localadmin": "Vantaa"
+            "name": "Kulokukonkuja 2"
           }
         ],
         "coordinates": [
@@ -12404,8 +11821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kulotie 8",
-            "localadmin": "Vantaa"
+            "name": "Kulotie 8"
           }
         ],
         "coordinates": [
@@ -12425,8 +11841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuminatie 35",
-            "localadmin": "Vantaa"
+            "name": "Kuminatie 35"
           }
         ],
         "coordinates": [
@@ -12446,8 +11861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kunnaantie 29",
-            "localadmin": "Vantaa"
+            "name": "Kunnaantie 29"
           }
         ],
         "coordinates": [
@@ -12467,8 +11881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuoppatie 4",
-            "localadmin": "Vantaa"
+            "name": "Kuoppatie 4"
           }
         ],
         "coordinates": [
@@ -12488,8 +11901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuoppatie 9",
-            "localadmin": "Vantaa"
+            "name": "Kuoppatie 9"
           }
         ],
         "coordinates": [
@@ -12509,8 +11921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuriiritie 32",
-            "localadmin": "Vantaa"
+            "name": "Kuriiritie 32"
           }
         ],
         "coordinates": [
@@ -12530,8 +11941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusikkokuja 6a",
-            "localadmin": "Vantaa"
+            "name": "Kuusikkokuja 6a"
           }
         ],
         "coordinates": [
@@ -12551,8 +11961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusikkotie 31",
-            "localadmin": "Vantaa"
+            "name": "Kuusikkotie 31"
           }
         ],
         "coordinates": [
@@ -12572,8 +11981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusistontie 28a",
-            "localadmin": "Vantaa"
+            "name": "Kuusistontie 28a"
           }
         ],
         "coordinates": [
@@ -12593,8 +12001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusitie 8",
-            "localadmin": "Vantaa"
+            "name": "Kuusitie 8"
           }
         ],
         "coordinates": [
@@ -12614,8 +12021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kustaantie 23b",
-            "localadmin": "Vantaa"
+            "name": "Kustaantie 23b"
           }
         ],
         "coordinates": [
@@ -12635,8 +12041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kustaantie 45b",
-            "localadmin": "Vantaa"
+            "name": "Kustaantie 45b"
           }
         ],
         "coordinates": [
@@ -12656,8 +12061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuussillankuja 6",
-            "localadmin": "Vantaa"
+            "name": "Kuussillankuja 6"
           }
         ],
         "coordinates": [
@@ -12677,8 +12081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuussillantie 2c",
-            "localadmin": "Vantaa"
+            "name": "Kuussillantie 2c"
           }
         ],
         "coordinates": [
@@ -12698,8 +12101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuussillantie 27",
-            "localadmin": "Vantaa"
+            "name": "Kuussillantie 27"
           }
         ],
         "coordinates": [
@@ -12719,8 +12121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laajapolku 1",
-            "localadmin": "Vantaa"
+            "name": "Laajapolku 1"
           }
         ],
         "coordinates": [
@@ -12740,8 +12141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksotie 17a",
-            "localadmin": "Vantaa"
+            "name": "Laaksotie 17a"
           }
         ],
         "coordinates": [
@@ -12761,8 +12161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lapintie 14",
-            "localadmin": "Vantaa"
+            "name": "Lapintie 14"
           }
         ],
         "coordinates": [
@@ -12782,8 +12181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Latvakuja 6",
-            "localadmin": "Vantaa"
+            "name": "Latvakuja 6"
           }
         ],
         "coordinates": [
@@ -12803,8 +12201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laulurastaankuja 4",
-            "localadmin": "Vantaa"
+            "name": "Laulurastaankuja 4"
           }
         ],
         "coordinates": [
@@ -12824,8 +12221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lauhatie 10",
-            "localadmin": "Vantaa"
+            "name": "Lauhatie 10"
           }
         ],
         "coordinates": [
@@ -12845,8 +12241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurintie 24",
-            "localadmin": "Vantaa"
+            "name": "Laurintie 24"
           }
         ],
         "coordinates": [
@@ -12866,8 +12261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurintie 37",
-            "localadmin": "Vantaa"
+            "name": "Laurintie 37"
           }
         ],
         "coordinates": [
@@ -12887,8 +12281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurintie 121",
-            "localadmin": "Vantaa"
+            "name": "Laurintie 121"
           }
         ],
         "coordinates": [
@@ -12908,8 +12301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leankuja 10",
-            "localadmin": "Vantaa"
+            "name": "Leankuja 10"
           }
         ],
         "coordinates": [
@@ -12929,8 +12321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehmuskuja 1",
-            "localadmin": "Vantaa"
+            "name": "Lehmuskuja 1"
           }
         ],
         "coordinates": [
@@ -12950,8 +12341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehtikummuntie 11",
-            "localadmin": "Vantaa"
+            "name": "Lehtikummuntie 11"
           }
         ],
         "coordinates": [
@@ -12971,8 +12361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lepomäentie 10",
-            "localadmin": "Vantaa"
+            "name": "Lepomäentie 10"
           }
         ],
         "coordinates": [
@@ -12992,8 +12381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leppäpirkontie 3",
-            "localadmin": "Vantaa"
+            "name": "Leppäpirkontie 3"
           }
         ],
         "coordinates": [
@@ -13013,8 +12401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leinikkitie 37",
-            "localadmin": "Vantaa"
+            "name": "Leinikkitie 37"
           }
         ],
         "coordinates": [
@@ -13034,8 +12421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leivonkuja 4",
-            "localadmin": "Vantaa"
+            "name": "Leivonkuja 4"
           }
         ],
         "coordinates": [
@@ -13055,8 +12441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Liisantie 4b",
-            "localadmin": "Vantaa"
+            "name": "Liisantie 4b"
           }
         ],
         "coordinates": [
@@ -13076,8 +12461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnaistentie 59b",
-            "localadmin": "Vantaa"
+            "name": "Linnaistentie 59b"
           }
         ],
         "coordinates": [
@@ -13097,8 +12481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnunrata 5",
-            "localadmin": "Vantaa"
+            "name": "Linnunrata 5"
           }
         ],
         "coordinates": [
@@ -13118,8 +12501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnaistentie 27",
-            "localadmin": "Vantaa"
+            "name": "Linnaistentie 27"
           }
         ],
         "coordinates": [
@@ -13139,8 +12521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Loimaankoivuntie 16",
-            "localadmin": "Vantaa"
+            "name": "Loimaankoivuntie 16"
           }
         ],
         "coordinates": [
@@ -13160,8 +12541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Loimitie 17b",
-            "localadmin": "Vantaa"
+            "name": "Loimitie 17b"
           }
         ],
         "coordinates": [
@@ -13181,8 +12561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lumikkotie 2",
-            "localadmin": "Vantaa"
+            "name": "Lumikkotie 2"
           }
         ],
         "coordinates": [
@@ -13202,8 +12581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lunnitie 12",
-            "localadmin": "Vantaa"
+            "name": "Lunnitie 12"
           }
         ],
         "coordinates": [
@@ -13223,8 +12601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lupiinikuja 5a",
-            "localadmin": "Vantaa"
+            "name": "Lupiinikuja 5a"
           }
         ],
         "coordinates": [
@@ -13244,8 +12621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Luutnantintie 33",
-            "localadmin": "Vantaa"
+            "name": "Luutnantintie 33"
           }
         ],
         "coordinates": [
@@ -13265,8 +12641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Länsimäentie 47",
-            "localadmin": "Vantaa"
+            "name": "Länsimäentie 47"
           }
         ],
         "coordinates": [
@@ -13286,8 +12661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Länsi-Keimolan Tie 1a",
-            "localadmin": "Vantaa"
+            "name": "Länsi-Keimolan Tie 1a"
           }
         ],
         "coordinates": [
@@ -13307,8 +12681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maamiehentie 11b",
-            "localadmin": "Vantaa"
+            "name": "Maamiehentie 11b"
           }
         ],
         "coordinates": [
@@ -13328,8 +12701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maarukankuja 8",
-            "localadmin": "Vantaa"
+            "name": "Maarukankuja 8"
           }
         ],
         "coordinates": [
@@ -13349,8 +12721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Majavarinne 1",
-            "localadmin": "Vantaa"
+            "name": "Majavarinne 1"
           }
         ],
         "coordinates": [
@@ -13370,8 +12741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Marmoritie 29b",
-            "localadmin": "Vantaa"
+            "name": "Marmoritie 29b"
           }
         ],
         "coordinates": [
@@ -13391,8 +12761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Marmoritie 41",
-            "localadmin": "Vantaa"
+            "name": "Marmoritie 41"
           }
         ],
         "coordinates": [
@@ -13412,8 +12781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Matarinkuja 3",
-            "localadmin": "Vantaa"
+            "name": "Matarinkuja 3"
           }
         ],
         "coordinates": [
@@ -13433,8 +12801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Martinlaaksontie 36b",
-            "localadmin": "Vantaa"
+            "name": "Martinlaaksontie 36b"
           }
         ],
         "coordinates": [
@@ -13454,8 +12821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Merineulantie 2",
-            "localadmin": "Vantaa"
+            "name": "Merineulantie 2"
           }
         ],
         "coordinates": [
@@ -13475,8 +12841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsolantie 21b",
-            "localadmin": "Vantaa"
+            "name": "Metsolantie 21b"
           }
         ],
         "coordinates": [
@@ -13496,8 +12861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsopolku 4b",
-            "localadmin": "Vantaa"
+            "name": "Metsopolku 4b"
           }
         ],
         "coordinates": [
@@ -13517,8 +12881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsätähdentie 21a",
-            "localadmin": "Vantaa"
+            "name": "Metsätähdentie 21a"
           }
         ],
         "coordinates": [
@@ -13538,8 +12901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Minttutie 7",
-            "localadmin": "Vantaa"
+            "name": "Minttutie 7"
           }
         ],
         "coordinates": [
@@ -13559,8 +12921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Minttutie 28",
-            "localadmin": "Vantaa"
+            "name": "Minttutie 28"
           }
         ],
         "coordinates": [
@@ -13580,8 +12941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Minttutie 33",
-            "localadmin": "Vantaa"
+            "name": "Minttutie 33"
           }
         ],
         "coordinates": [
@@ -13601,8 +12961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Murmelikuja 5",
-            "localadmin": "Vantaa"
+            "name": "Murmelikuja 5"
           }
         ],
         "coordinates": [
@@ -13622,8 +12981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Murmelikuja 16",
-            "localadmin": "Vantaa"
+            "name": "Murmelikuja 16"
           }
         ],
         "coordinates": [
@@ -13643,8 +13001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Myllymäentie 8a",
-            "localadmin": "Vantaa"
+            "name": "Myllymäentie 8a"
           }
         ],
         "coordinates": [
@@ -13664,8 +13021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Naakkatie 14",
-            "localadmin": "Vantaa"
+            "name": "Naakkatie 14"
           }
         ],
         "coordinates": [
@@ -13685,8 +13041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Naalitie 11",
-            "localadmin": "Vantaa"
+            "name": "Naalitie 11"
           }
         ],
         "coordinates": [
@@ -13706,8 +13061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäyräkuja 2",
-            "localadmin": "Vantaa"
+            "name": "Mäyräkuja 2"
           }
         ],
         "coordinates": [
@@ -13727,8 +13081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Naulakuja 8",
-            "localadmin": "Vantaa"
+            "name": "Naulakuja 8"
           }
         ],
         "coordinates": [
@@ -13748,8 +13101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Niittytie 12",
-            "localadmin": "Vantaa"
+            "name": "Niittytie 12"
           }
         ],
         "coordinates": [
@@ -13769,8 +13121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Normannipolku 3",
-            "localadmin": "Vantaa"
+            "name": "Normannipolku 3"
           }
         ],
         "coordinates": [
@@ -13790,8 +13141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ojahaantie 5",
-            "localadmin": "Vantaa"
+            "name": "Ojahaantie 5"
           }
         ],
         "coordinates": [
@@ -13811,8 +13161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Onervantie 30",
-            "localadmin": "Vantaa"
+            "name": "Onervantie 30"
           }
         ],
         "coordinates": [
@@ -13832,8 +13181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Onervantie 37",
-            "localadmin": "Vantaa"
+            "name": "Onervantie 37"
           }
         ],
         "coordinates": [
@@ -13853,8 +13201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Onkimadonpolku 2b",
-            "localadmin": "Vantaa"
+            "name": "Onkimadonpolku 2b"
           }
         ],
         "coordinates": [
@@ -13874,8 +13221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ongenkoukku 21",
-            "localadmin": "Vantaa"
+            "name": "Ongenkoukku 21"
           }
         ],
         "coordinates": [
@@ -13895,8 +13241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osmankäämintie 12",
-            "localadmin": "Vantaa"
+            "name": "Osmankäämintie 12"
           }
         ],
         "coordinates": [
@@ -13916,8 +13261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osmankäämintie 64",
-            "localadmin": "Vantaa"
+            "name": "Osmankäämintie 64"
           }
         ],
         "coordinates": [
@@ -13937,8 +13281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Osmankäämintie 70",
-            "localadmin": "Vantaa"
+            "name": "Osmankäämintie 70"
           }
         ],
         "coordinates": [
@@ -13958,8 +13301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakkalanrinne 8",
-            "localadmin": "Vantaa"
+            "name": "Pakkalanrinne 8"
           }
         ],
         "coordinates": [
@@ -13979,8 +13321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakkalanrinne 10",
-            "localadmin": "Vantaa"
+            "name": "Pakkalanrinne 10"
           }
         ],
         "coordinates": [
@@ -14000,8 +13341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakkalantie 11",
-            "localadmin": "Vantaa"
+            "name": "Pakkalantie 11"
           }
         ],
         "coordinates": [
@@ -14021,8 +13361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pallastunturintie 34",
-            "localadmin": "Vantaa"
+            "name": "Pallastunturintie 34"
           }
         ],
         "coordinates": [
@@ -14042,8 +13381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pallotie 4b",
-            "localadmin": "Vantaa"
+            "name": "Pallotie 4b"
           }
         ],
         "coordinates": [
@@ -14063,8 +13401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakkaskuja 1",
-            "localadmin": "Vantaa"
+            "name": "Pakkaskuja 1"
           }
         ],
         "coordinates": [
@@ -14084,8 +13421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pallotie 28b",
-            "localadmin": "Vantaa"
+            "name": "Pallotie 28b"
           }
         ],
         "coordinates": [
@@ -14105,8 +13441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peitsipolku 2",
-            "localadmin": "Vantaa"
+            "name": "Peitsipolku 2"
           }
         ],
         "coordinates": [
@@ -14126,8 +13461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peitsitie 5c",
-            "localadmin": "Vantaa"
+            "name": "Peitsitie 5c"
           }
         ],
         "coordinates": [
@@ -14147,8 +13481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perhotie 39a",
-            "localadmin": "Vantaa"
+            "name": "Perhotie 39a"
           }
         ],
         "coordinates": [
@@ -14168,8 +13501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perkiönkuja 1b",
-            "localadmin": "Vantaa"
+            "name": "Perkiönkuja 1b"
           }
         ],
         "coordinates": [
@@ -14189,8 +13521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perkiönreuna 2d",
-            "localadmin": "Vantaa"
+            "name": "Perkiönreuna 2d"
           }
         ],
         "coordinates": [
@@ -14210,8 +13541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peräjäntie 21",
-            "localadmin": "Vantaa"
+            "name": "Peräjäntie 21"
           }
         ],
         "coordinates": [
@@ -14231,8 +13561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihapolku 6",
-            "localadmin": "Vantaa"
+            "name": "Pihapolku 6"
           }
         ],
         "coordinates": [
@@ -14252,8 +13581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pirjontie 4",
-            "localadmin": "Vantaa"
+            "name": "Pirjontie 4"
           }
         ],
         "coordinates": [
@@ -14273,8 +13601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjois-Viinikkalan Tie 9",
-            "localadmin": "Vantaa"
+            "name": "Pohjois-Viinikkalan Tie 9"
           }
         ],
         "coordinates": [
@@ -14294,8 +13621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Prinssintie 5",
-            "localadmin": "Vantaa"
+            "name": "Prinssintie 5"
           }
         ],
         "coordinates": [
@@ -14315,8 +13641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Purokuja 4b",
-            "localadmin": "Vantaa"
+            "name": "Purokuja 4b"
           }
         ],
         "coordinates": [
@@ -14336,8 +13661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Purotie 14",
-            "localadmin": "Vantaa"
+            "name": "Purotie 14"
           }
         ],
         "coordinates": [
@@ -14357,8 +13681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pyörrekuja 1a",
-            "localadmin": "Vantaa"
+            "name": "Pyörrekuja 1a"
           }
         ],
         "coordinates": [
@@ -14378,8 +13701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pyymosantie 9",
-            "localadmin": "Vantaa"
+            "name": "Pyymosantie 9"
           }
         ],
         "coordinates": [
@@ -14399,8 +13721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pyörätie 41a",
-            "localadmin": "Vantaa"
+            "name": "Pyörätie 41a"
           }
         ],
         "coordinates": [
@@ -14420,8 +13741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pähkinärinteentie 50",
-            "localadmin": "Vantaa"
+            "name": "Pähkinärinteentie 50"
           }
         ],
         "coordinates": [
@@ -14441,8 +13761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänkakkarantie 12",
-            "localadmin": "Vantaa"
+            "name": "Päivänkakkarantie 12"
           }
         ],
         "coordinates": [
@@ -14462,8 +13781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pääskyläntie 5",
-            "localadmin": "Vantaa"
+            "name": "Pääskyläntie 5"
           }
         ],
         "coordinates": [
@@ -14483,8 +13801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajakalliontie 2",
-            "localadmin": "Vantaa"
+            "name": "Rajakalliontie 2"
           }
         ],
         "coordinates": [
@@ -14504,8 +13821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raappavuorentie 10",
-            "localadmin": "Vantaa"
+            "name": "Raappavuorentie 10"
           }
         ],
         "coordinates": [
@@ -14525,8 +13841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raitatie 17b",
-            "localadmin": "Vantaa"
+            "name": "Raitatie 17b"
           }
         ],
         "coordinates": [
@@ -14546,8 +13861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajakoskentie 29",
-            "localadmin": "Vantaa"
+            "name": "Rajakoskentie 29"
           }
         ],
         "coordinates": [
@@ -14567,8 +13881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajapolku 4",
-            "localadmin": "Vantaa"
+            "name": "Rajapolku 4"
           }
         ],
         "coordinates": [
@@ -14588,8 +13901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rasinkatu 1",
-            "localadmin": "Vantaa"
+            "name": "Rasinkatu 1"
           }
         ],
         "coordinates": [
@@ -14609,8 +13921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raudikkokuja 7",
-            "localadmin": "Vantaa"
+            "name": "Raudikkokuja 7"
           }
         ],
         "coordinates": [
@@ -14630,8 +13941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rauhalantie 29",
-            "localadmin": "Vantaa"
+            "name": "Rauhalantie 29"
           }
         ],
         "coordinates": [
@@ -14651,8 +13961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Reinontie 10",
-            "localadmin": "Vantaa"
+            "name": "Reinontie 10"
           }
         ],
         "coordinates": [
@@ -14672,8 +13981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rekolankuja 1",
-            "localadmin": "Vantaa"
+            "name": "Rekolankuja 1"
           }
         ],
         "coordinates": [
@@ -14693,8 +14001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Riipiläntie 68",
-            "localadmin": "Vantaa"
+            "name": "Riipiläntie 68"
           }
         ],
         "coordinates": [
@@ -14714,8 +14021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ritvanpolku 4",
-            "localadmin": "Vantaa"
+            "name": "Ritvanpolku 4"
           }
         ],
         "coordinates": [
@@ -14735,8 +14041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ritvantie 28b",
-            "localadmin": "Vantaa"
+            "name": "Ritvantie 28b"
           }
         ],
         "coordinates": [
@@ -14756,8 +14061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rubiinikehä 16",
-            "localadmin": "Vantaa"
+            "name": "Rubiinikehä 16"
           }
         ],
         "coordinates": [
@@ -14777,8 +14081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rukkitie 2b",
-            "localadmin": "Vantaa"
+            "name": "Rukkitie 2b"
           }
         ],
         "coordinates": [
@@ -14798,8 +14101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruusutie 4b",
-            "localadmin": "Vantaa"
+            "name": "Ruusutie 4b"
           }
         ],
         "coordinates": [
@@ -14819,8 +14121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saarantie 13a",
-            "localadmin": "Vantaa"
+            "name": "Saarantie 13a"
           }
         ],
         "coordinates": [
@@ -14840,8 +14141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Saarnirinne 2c",
-            "localadmin": "Vantaa"
+            "name": "Saarnirinne 2c"
           }
         ],
         "coordinates": [
@@ -14861,8 +14161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Salakkakuja 7",
-            "localadmin": "Vantaa"
+            "name": "Salakkakuja 7"
           }
         ],
         "coordinates": [
@@ -14882,8 +14181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sampsankuja 4",
-            "localadmin": "Vantaa"
+            "name": "Sampsankuja 4"
           }
         ],
         "coordinates": [
@@ -14903,8 +14201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Santaradantie 5",
-            "localadmin": "Vantaa"
+            "name": "Santaradantie 5"
           }
         ],
         "coordinates": [
@@ -14924,8 +14221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sarvijaakonpolku 6a",
-            "localadmin": "Vantaa"
+            "name": "Sarvijaakonpolku 6a"
           }
         ],
         "coordinates": [
@@ -14945,8 +14241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Seivästie 3",
-            "localadmin": "Vantaa"
+            "name": "Seivästie 3"
           }
         ],
         "coordinates": [
@@ -14966,8 +14261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Seppäläntie 6d",
-            "localadmin": "Vantaa"
+            "name": "Seppäläntie 6d"
           }
         ],
         "coordinates": [
@@ -14987,8 +14281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sienestäjänkuja 9",
-            "localadmin": "Vantaa"
+            "name": "Sienestäjänkuja 9"
           }
         ],
         "coordinates": [
@@ -15008,8 +14301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sauramontie 12",
-            "localadmin": "Vantaa"
+            "name": "Sauramontie 12"
           }
         ],
         "coordinates": [
@@ -15029,8 +14321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sauramontie 19",
-            "localadmin": "Vantaa"
+            "name": "Sauramontie 19"
           }
         ],
         "coordinates": [
@@ -15050,8 +14341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Silatie 17",
-            "localadmin": "Vantaa"
+            "name": "Silatie 17"
           }
         ],
         "coordinates": [
@@ -15071,8 +14361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Simonpolku 3",
-            "localadmin": "Vantaa"
+            "name": "Simonpolku 3"
           }
         ],
         "coordinates": [
@@ -15092,8 +14381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Simontie 2",
-            "localadmin": "Vantaa"
+            "name": "Simontie 2"
           }
         ],
         "coordinates": [
@@ -15113,8 +14401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinikantie 6a",
-            "localadmin": "Vantaa"
+            "name": "Sinikantie 6a"
           }
         ],
         "coordinates": [
@@ -15134,8 +14421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinirikontie 13",
-            "localadmin": "Vantaa"
+            "name": "Sinirikontie 13"
           }
         ],
         "coordinates": [
@@ -15155,8 +14441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinisiiventie 15",
-            "localadmin": "Vantaa"
+            "name": "Sinisiiventie 15"
           }
         ],
         "coordinates": [
@@ -15176,8 +14461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Skinnarintie 2",
-            "localadmin": "Vantaa"
+            "name": "Skinnarintie 2"
           }
         ],
         "coordinates": [
@@ -15197,8 +14481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sointukuja 2",
-            "localadmin": "Vantaa"
+            "name": "Sointukuja 2"
           }
         ],
         "coordinates": [
@@ -15218,8 +14501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sointukuja 8",
-            "localadmin": "Vantaa"
+            "name": "Sointukuja 8"
           }
         ],
         "coordinates": [
@@ -15239,8 +14521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvatie 27",
-            "localadmin": "Vantaa"
+            "name": "Sorvatie 27"
           }
         ],
         "coordinates": [
@@ -15260,8 +14541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotilaskorventie 5",
-            "localadmin": "Vantaa"
+            "name": "Sotilaskorventie 5"
           }
         ],
         "coordinates": [
@@ -15281,8 +14561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotkakuja 1b",
-            "localadmin": "Vantaa"
+            "name": "Sotkakuja 1b"
           }
         ],
         "coordinates": [
@@ -15302,8 +14581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorsatie 9",
-            "localadmin": "Vantaa"
+            "name": "Sorsatie 9"
           }
         ],
         "coordinates": [
@@ -15323,8 +14601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sydäntie 12",
-            "localadmin": "Vantaa"
+            "name": "Sydäntie 12"
           }
         ],
         "coordinates": [
@@ -15344,8 +14621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säveltie 3",
-            "localadmin": "Vantaa"
+            "name": "Säveltie 3"
           }
         ],
         "coordinates": [
@@ -15365,8 +14641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sääskitie 44b",
-            "localadmin": "Vantaa"
+            "name": "Sääskitie 44b"
           }
         ],
         "coordinates": [
@@ -15386,8 +14661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Talvikkitie 43",
-            "localadmin": "Vantaa"
+            "name": "Talvikkitie 43"
           }
         ],
         "coordinates": [
@@ -15407,8 +14681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Talvikkitie 77a",
-            "localadmin": "Vantaa"
+            "name": "Talvikkitie 77a"
           }
         ],
         "coordinates": [
@@ -15428,8 +14701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammistonkuja 2",
-            "localadmin": "Vantaa"
+            "name": "Tammistonkuja 2"
           }
         ],
         "coordinates": [
@@ -15449,8 +14721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tanssijantie 7",
-            "localadmin": "Vantaa"
+            "name": "Tanssijantie 7"
           }
         ],
         "coordinates": [
@@ -15470,8 +14741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tapolantie 36",
-            "localadmin": "Vantaa"
+            "name": "Tapolantie 36"
           }
         ],
         "coordinates": [
@@ -15491,8 +14761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tattipolku 1",
-            "localadmin": "Vantaa"
+            "name": "Tattipolku 1"
           }
         ],
         "coordinates": [
@@ -15512,8 +14781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tavitie 16",
-            "localadmin": "Vantaa"
+            "name": "Tavitie 16"
           }
         ],
         "coordinates": [
@@ -15533,8 +14801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tarhurintie 29",
-            "localadmin": "Vantaa"
+            "name": "Tarhurintie 29"
           }
         ],
         "coordinates": [
@@ -15554,8 +14821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Telkkätie 12",
-            "localadmin": "Vantaa"
+            "name": "Telkkätie 12"
           }
         ],
         "coordinates": [
@@ -15575,8 +14841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiirakuja 7",
-            "localadmin": "Vantaa"
+            "name": "Tiirakuja 7"
           }
         ],
         "coordinates": [
@@ -15596,8 +14861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tikkurilantie 126",
-            "localadmin": "Vantaa"
+            "name": "Tikkurilantie 126"
           }
         ],
         "coordinates": [
@@ -15617,8 +14881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Toivonrinne 9",
-            "localadmin": "Vantaa"
+            "name": "Toivonrinne 9"
           }
         ],
         "coordinates": [
@@ -15638,8 +14901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuliniementie 3",
-            "localadmin": "Vantaa"
+            "name": "Tuliniementie 3"
           }
         ],
         "coordinates": [
@@ -15659,8 +14921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulppaanikuja 4a",
-            "localadmin": "Vantaa"
+            "name": "Tulppaanikuja 4a"
           }
         ],
         "coordinates": [
@@ -15680,8 +14941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Turvetie 22",
-            "localadmin": "Vantaa"
+            "name": "Turvetie 22"
           }
         ],
         "coordinates": [
@@ -15701,8 +14961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuusulantie 120",
-            "localadmin": "Vantaa"
+            "name": "Tuusulantie 120"
           }
         ],
         "coordinates": [
@@ -15722,8 +14981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tykkipolku 2",
-            "localadmin": "Vantaa"
+            "name": "Tykkipolku 2"
           }
         ],
         "coordinates": [
@@ -15743,8 +15001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tyyneläntie 6",
-            "localadmin": "Vantaa"
+            "name": "Tyyneläntie 6"
           }
         ],
         "coordinates": [
@@ -15764,8 +15021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenkyläntie 3",
-            "localadmin": "Vantaa"
+            "name": "Uudenkyläntie 3"
           }
         ],
         "coordinates": [
@@ -15785,8 +15041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uurrekuja 14b",
-            "localadmin": "Vantaa"
+            "name": "Uurrekuja 14b"
           }
         ],
         "coordinates": [
@@ -15806,8 +15061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uurrekuja 23",
-            "localadmin": "Vantaa"
+            "name": "Uurrekuja 23"
           }
         ],
         "coordinates": [
@@ -15827,8 +15081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Urheilutie 7",
-            "localadmin": "Vantaa"
+            "name": "Urheilutie 7"
           }
         ],
         "coordinates": [
@@ -15848,8 +15101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uusiniitynpolku 1",
-            "localadmin": "Vantaa"
+            "name": "Uusiniitynpolku 1"
           }
         ],
         "coordinates": [
@@ -15869,8 +15121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Uusiraja 9",
-            "localadmin": "Vantaa"
+            "name": "Uusiraja 9"
           }
         ],
         "coordinates": [
@@ -15890,8 +15141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaahtokuja 1",
-            "localadmin": "Vantaa"
+            "name": "Vaahtokuja 1"
           }
         ],
         "coordinates": [
@@ -15911,8 +15161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaaralantie 24",
-            "localadmin": "Vantaa"
+            "name": "Vaaralantie 24"
           }
         ],
         "coordinates": [
@@ -15932,8 +15181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahverokuja 16",
-            "localadmin": "Vantaa"
+            "name": "Vahverokuja 16"
           }
         ],
         "coordinates": [
@@ -15953,8 +15201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Valinkauhantie 10b",
-            "localadmin": "Vantaa"
+            "name": "Valinkauhantie 10b"
           }
         ],
         "coordinates": [
@@ -15974,8 +15221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Valtimotie 4",
-            "localadmin": "Vantaa"
+            "name": "Valtimotie 4"
           }
         ],
         "coordinates": [
@@ -15995,8 +15241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Kaarelantie 27",
-            "localadmin": "Vantaa"
+            "name": "Vanha Kaarelantie 27"
           }
         ],
         "coordinates": [
@@ -16016,8 +15261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Porvoontie 358c",
-            "localadmin": "Vantaa"
+            "name": "Vanha Porvoontie 358c"
           }
         ],
         "coordinates": [
@@ -16037,8 +15281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Porvoontie 364",
-            "localadmin": "Vantaa"
+            "name": "Vanha Porvoontie 364"
           }
         ],
         "coordinates": [
@@ -16058,8 +15301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhankyläntie 1",
-            "localadmin": "Vantaa"
+            "name": "Vanhankyläntie 1"
           }
         ],
         "coordinates": [
@@ -16079,8 +15321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhatie 4",
-            "localadmin": "Vantaa"
+            "name": "Vanhatie 4"
           }
         ],
         "coordinates": [
@@ -16100,8 +15341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vankkurikuja 13",
-            "localadmin": "Vantaa"
+            "name": "Vankkurikuja 13"
           }
         ],
         "coordinates": [
@@ -16121,8 +15361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Varistontie 1a",
-            "localadmin": "Vantaa"
+            "name": "Varistontie 1a"
           }
         ],
         "coordinates": [
@@ -16142,8 +15381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Varpukalliontie 9b",
-            "localadmin": "Vantaa"
+            "name": "Varpukalliontie 9b"
           }
         ],
         "coordinates": [
@@ -16163,8 +15401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Variskuja 3",
-            "localadmin": "Vantaa"
+            "name": "Variskuja 3"
           }
         ],
         "coordinates": [
@@ -16184,8 +15421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Varstatie 10c",
-            "localadmin": "Vantaa"
+            "name": "Varstatie 10c"
           }
         ],
         "coordinates": [
@@ -16205,8 +15441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vartiotie 13",
-            "localadmin": "Vantaa"
+            "name": "Vartiotie 13"
           }
         ],
         "coordinates": [
@@ -16226,8 +15461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkalantie 9",
-            "localadmin": "Vantaa"
+            "name": "Vehkalantie 9"
           }
         ],
         "coordinates": [
@@ -16247,8 +15481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vestrantie 4",
-            "localadmin": "Vantaa"
+            "name": "Vestrantie 4"
           }
         ],
         "coordinates": [
@@ -16268,8 +15501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vestrantie 6",
-            "localadmin": "Vantaa"
+            "name": "Vestrantie 6"
           }
         ],
         "coordinates": [
@@ -16289,8 +15521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vestrantie 112",
-            "localadmin": "Vantaa"
+            "name": "Vestrantie 112"
           }
         ],
         "coordinates": [
@@ -16310,8 +15541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vestrantie 118",
-            "localadmin": "Vantaa"
+            "name": "Vestrantie 118"
           }
         ],
         "coordinates": [
@@ -16331,8 +15561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viertotie 21",
-            "localadmin": "Vantaa"
+            "name": "Viertotie 21"
           }
         ],
         "coordinates": [
@@ -16352,8 +15581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vierumäentie 41",
-            "localadmin": "Vantaa"
+            "name": "Vierumäentie 41"
           }
         ],
         "coordinates": [
@@ -16373,8 +15601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viestitie 42",
-            "localadmin": "Vantaa"
+            "name": "Viestitie 42"
           }
         ],
         "coordinates": [
@@ -16394,8 +15621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vieteritie 1",
-            "localadmin": "Vantaa"
+            "name": "Vieteritie 1"
           }
         ],
         "coordinates": [
@@ -16415,8 +15641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vihertie 17a",
-            "localadmin": "Vantaa"
+            "name": "Vihertie 17a"
           }
         ],
         "coordinates": [
@@ -16436,8 +15661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viholaisentie 14",
-            "localadmin": "Vantaa"
+            "name": "Viholaisentie 14"
           }
         ],
         "coordinates": [
@@ -16457,8 +15681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viinikankaari 2",
-            "localadmin": "Vantaa"
+            "name": "Viinikankaari 2"
           }
         ],
         "coordinates": [
@@ -16478,8 +15701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viklotie 9",
-            "localadmin": "Vantaa"
+            "name": "Viklotie 9"
           }
         ],
         "coordinates": [
@@ -16499,8 +15721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Villisiantie 30",
-            "localadmin": "Vantaa"
+            "name": "Villisiantie 30"
           }
         ],
         "coordinates": [
@@ -16520,8 +15741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viittatie 25",
-            "localadmin": "Vantaa"
+            "name": "Viittatie 25"
           }
         ],
         "coordinates": [
@@ -16541,8 +15761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuohipolku 5a",
-            "localadmin": "Vantaa"
+            "name": "Vuohipolku 5a"
           }
         ],
         "coordinates": [
@@ -16562,8 +15781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Voimalantie 13",
-            "localadmin": "Vantaa"
+            "name": "Voimalantie 13"
           }
         ],
         "coordinates": [
@@ -16583,8 +15801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoritie 15a",
-            "localadmin": "Vantaa"
+            "name": "Vuoritie 15a"
           }
         ],
         "coordinates": [
@@ -16604,8 +15821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoritie 16a",
-            "localadmin": "Vantaa"
+            "name": "Vuoritie 16a"
           }
         ],
         "coordinates": [
@@ -16625,8 +15841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Väritehtaankatu 6",
-            "localadmin": "Vantaa"
+            "name": "Väritehtaankatu 6"
           }
         ],
         "coordinates": [
@@ -16646,8 +15861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Äyritie 15b",
-            "localadmin": "Vantaa"
+            "name": "Äyritie 15b"
           }
         ],
         "coordinates": [
@@ -16667,8 +15881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hyljetie 26",
-            "localadmin": "Espoo"
+            "name": "Hyljetie 26"
           }
         ],
         "coordinates": [
@@ -16688,8 +15901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hämäläistentie 30",
-            "localadmin": "Espoo"
+            "name": "Hämäläistentie 30"
           }
         ],
         "coordinates": [
@@ -16709,8 +15921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hopearinne 7",
-            "localadmin": "Espoo"
+            "name": "Hopearinne 7"
           }
         ],
         "coordinates": [
@@ -16730,8 +15941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Iirislahdentie 34",
-            "localadmin": "Espoo"
+            "name": "Iirislahdentie 34"
           }
         ],
         "coordinates": [
@@ -16751,8 +15961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Inglaksenrinne 4c",
-            "localadmin": "Espoo"
+            "name": "Inglaksenrinne 4c"
           }
         ],
         "coordinates": [
@@ -16772,8 +15981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Juvan Teollisuuskatu 21a",
-            "localadmin": "Espoo"
+            "name": "Juvan Teollisuuskatu 21a"
           }
         ],
         "coordinates": [
@@ -16793,8 +16001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Joupinlaaksonkuja 3",
-            "localadmin": "Espoo"
+            "name": "Joupinlaaksonkuja 3"
           }
         ],
         "coordinates": [
@@ -16814,8 +16021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalliotie 14",
-            "localadmin": "Espoo"
+            "name": "Kalliotie 14"
           }
         ],
         "coordinates": [
@@ -16835,8 +16041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalmarintie 16b",
-            "localadmin": "Espoo"
+            "name": "Kalmarintie 16b"
           }
         ],
         "coordinates": [
@@ -16856,8 +16061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kallionsyrjä 13",
-            "localadmin": "Espoo"
+            "name": "Kallionsyrjä 13"
           }
         ],
         "coordinates": [
@@ -16877,8 +16081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhunhammas 8",
-            "localadmin": "Espoo"
+            "name": "Karhunhammas 8"
           }
         ],
         "coordinates": [
@@ -16898,8 +16101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karvarousku 6",
-            "localadmin": "Espoo"
+            "name": "Karvarousku 6"
           }
         ],
         "coordinates": [
@@ -16919,8 +16121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaunokkipolku 11",
-            "localadmin": "Espoo"
+            "name": "Kaunokkipolku 11"
           }
         ],
         "coordinates": [
@@ -16940,8 +16141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiiltokallionkuja 1b",
-            "localadmin": "Espoo"
+            "name": "Kiiltokallionkuja 1b"
           }
         ],
         "coordinates": [
@@ -16961,8 +16161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiiltokalliontie 40",
-            "localadmin": "Espoo"
+            "name": "Kiiltokalliontie 40"
           }
         ],
         "coordinates": [
@@ -16982,8 +16181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirjoniitty 3",
-            "localadmin": "Espoo"
+            "name": "Kirjoniitty 3"
           }
         ],
         "coordinates": [
@@ -17003,8 +16201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirkkonummentie 10",
-            "localadmin": "Espoo"
+            "name": "Kirkkonummentie 10"
           }
         ],
         "coordinates": [
@@ -17024,8 +16221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kellokuja 4",
-            "localadmin": "Espoo"
+            "name": "Kellokuja 4"
           }
         ],
         "coordinates": [
@@ -17045,8 +16241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirstinharju 1",
-            "localadmin": "Espoo"
+            "name": "Kirstinharju 1"
           }
         ],
         "coordinates": [
@@ -17066,8 +16261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivusyrjä 19",
-            "localadmin": "Espoo"
+            "name": "Koivusyrjä 19"
           }
         ],
         "coordinates": [
@@ -17087,8 +16281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivitie 8",
-            "localadmin": "Espoo"
+            "name": "Kivitie 8"
           }
         ],
         "coordinates": [
@@ -17108,8 +16301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulumestarintie 11",
-            "localadmin": "Espoo"
+            "name": "Koulumestarintie 11"
           }
         ],
         "coordinates": [
@@ -17129,8 +16321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurtintie 3",
-            "localadmin": "Espoo"
+            "name": "Kurtintie 3"
           }
         ],
         "coordinates": [
@@ -17150,8 +16341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kustaanmäki 4",
-            "localadmin": "Espoo"
+            "name": "Kustaanmäki 4"
           }
         ],
         "coordinates": [
@@ -17171,8 +16361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lakitie 9b",
-            "localadmin": "Espoo"
+            "name": "Lakitie 9b"
           }
         ],
         "coordinates": [
@@ -17192,8 +16381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintuvaarantie 2",
-            "localadmin": "Espoo"
+            "name": "Lintuvaarantie 2"
           }
         ],
         "coordinates": [
@@ -17213,8 +16401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lippajärventie 32",
-            "localadmin": "Espoo"
+            "name": "Lippajärventie 32"
           }
         ],
         "coordinates": [
@@ -17234,8 +16421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnustajantie 7",
-            "localadmin": "Espoo"
+            "name": "Linnustajantie 7"
           }
         ],
         "coordinates": [
@@ -17255,8 +16441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mariannantie 38",
-            "localadmin": "Espoo"
+            "name": "Mariannantie 38"
           }
         ],
         "coordinates": [
@@ -17276,8 +16461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Masalantie 3b",
-            "localadmin": "Espoo"
+            "name": "Masalantie 3b"
           }
         ],
         "coordinates": [
@@ -17297,8 +16481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkkylän Puistotie 12",
-            "localadmin": "Espoo"
+            "name": "Mäkkylän Puistotie 12"
           }
         ],
         "coordinates": [
@@ -17318,8 +16501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nelivaljakontie 6",
-            "localadmin": "Espoo"
+            "name": "Nelivaljakontie 6"
           }
         ],
         "coordinates": [
@@ -17339,8 +16521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuolitie 10",
-            "localadmin": "Espoo"
+            "name": "Nuolitie 10"
           }
         ],
         "coordinates": [
@@ -17360,8 +16541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Norokuja 5",
-            "localadmin": "Espoo"
+            "name": "Norokuja 5"
           }
         ],
         "coordinates": [
@@ -17381,8 +16561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nummikuja 7",
-            "localadmin": "Espoo"
+            "name": "Nummikuja 7"
           }
         ],
         "coordinates": [
@@ -17402,8 +16581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peipontie 10",
-            "localadmin": "Espoo"
+            "name": "Peipontie 10"
           }
         ],
         "coordinates": [
@@ -17423,8 +16601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peringintie 6",
-            "localadmin": "Espoo"
+            "name": "Peringintie 6"
           }
         ],
         "coordinates": [
@@ -17444,8 +16621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajamarjantie 18",
-            "localadmin": "Espoo"
+            "name": "Pihlajamarjantie 18"
           }
         ],
         "coordinates": [
@@ -17465,8 +16641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pentala 280",
-            "localadmin": "Espoo"
+            "name": "Pentala 280"
           }
         ],
         "coordinates": [
@@ -17486,8 +16661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Poppelikuja 1",
-            "localadmin": "Espoo"
+            "name": "Poppelikuja 1"
           }
         ],
         "coordinates": [
@@ -17507,8 +16681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pukkisaari 20",
-            "localadmin": "Espoo"
+            "name": "Pukkisaari 20"
           }
         ],
         "coordinates": [
@@ -17528,8 +16701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rantavallintie 5",
-            "localadmin": "Espoo"
+            "name": "Rantavallintie 5"
           }
         ],
         "coordinates": [
@@ -17549,8 +16721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Raatepolku 10",
-            "localadmin": "Espoo"
+            "name": "Raatepolku 10"
           }
         ],
         "coordinates": [
@@ -17570,8 +16741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Riistatie 22",
-            "localadmin": "Espoo"
+            "name": "Riistatie 22"
           }
         ],
         "coordinates": [
@@ -17591,8 +16761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Röyläntie 7b",
-            "localadmin": "Espoo"
+            "name": "Röyläntie 7b"
           }
         ],
         "coordinates": [
@@ -17612,8 +16781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Röyläntie 15",
-            "localadmin": "Espoo"
+            "name": "Röyläntie 15"
           }
         ],
         "coordinates": [
@@ -17633,8 +16801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Santaharjuntie 4",
-            "localadmin": "Espoo"
+            "name": "Santaharjuntie 4"
           }
         ],
         "coordinates": [
@@ -17654,8 +16821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siikajärventie 52",
-            "localadmin": "Espoo"
+            "name": "Siikajärventie 52"
           }
         ],
         "coordinates": [
@@ -17675,8 +16841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siuntionkuja 1",
-            "localadmin": "Espoo"
+            "name": "Siuntionkuja 1"
           }
         ],
         "coordinates": [
@@ -17696,8 +16861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Siuntiontie 9",
-            "localadmin": "Espoo"
+            "name": "Siuntiontie 9"
           }
         ],
         "coordinates": [
@@ -17717,8 +16881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukan Rantatie 20",
-            "localadmin": "Espoo"
+            "name": "Soukan Rantatie 20"
           }
         ],
         "coordinates": [
@@ -17738,8 +16901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Stenbackantie 6",
-            "localadmin": "Espoo"
+            "name": "Stenbackantie 6"
           }
         ],
         "coordinates": [
@@ -17759,8 +16921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suokalliontie 8",
-            "localadmin": "Espoo"
+            "name": "Suokalliontie 8"
           }
         ],
         "coordinates": [
@@ -17780,8 +16941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suvikummunpolku 12",
-            "localadmin": "Espoo"
+            "name": "Suvikummunpolku 12"
           }
         ],
         "coordinates": [
@@ -17801,8 +16961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sysimaa 4",
-            "localadmin": "Espoo"
+            "name": "Sysimaa 4"
           }
         ],
         "coordinates": [
@@ -17822,8 +16981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suopuronmäki 10",
-            "localadmin": "Espoo"
+            "name": "Suopuronmäki 10"
           }
         ],
         "coordinates": [
@@ -17843,8 +17001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säkkijärventie 8",
-            "localadmin": "Espoo"
+            "name": "Säkkijärventie 8"
           }
         ],
         "coordinates": [
@@ -17864,8 +17021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tallimestarintie 2",
-            "localadmin": "Espoo"
+            "name": "Tallimestarintie 2"
           }
         ],
         "coordinates": [
@@ -17885,8 +17041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tapiontie 22",
-            "localadmin": "Espoo"
+            "name": "Tapiontie 22"
           }
         ],
         "coordinates": [
@@ -17906,8 +17061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavilantie 4",
-            "localadmin": "Espoo"
+            "name": "Taavilantie 4"
           }
         ],
         "coordinates": [
@@ -17927,8 +17081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tinapuisto 1",
-            "localadmin": "Espoo"
+            "name": "Tinapuisto 1"
           }
         ],
         "coordinates": [
@@ -17948,8 +17101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tähtikalliontie 26",
-            "localadmin": "Espoo"
+            "name": "Tähtikalliontie 26"
           }
         ],
         "coordinates": [
@@ -17969,8 +17121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaasanrinne 6",
-            "localadmin": "Espoo"
+            "name": "Vaasanrinne 6"
           }
         ],
         "coordinates": [
@@ -17990,8 +17141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Sveinsintie 1",
-            "localadmin": "Espoo"
+            "name": "Vanha Sveinsintie 1"
           }
         ],
         "coordinates": [
@@ -18011,8 +17161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Varsikengäntie 21",
-            "localadmin": "Espoo"
+            "name": "Varsikengäntie 21"
           }
         ],
         "coordinates": [
@@ -18032,8 +17181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahverotie 9",
-            "localadmin": "Espoo"
+            "name": "Vahverotie 9"
           }
         ],
         "coordinates": [
@@ -18053,8 +17201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vasaramäki 2",
-            "localadmin": "Espoo"
+            "name": "Vasaramäki 2"
           }
         ],
         "coordinates": [
@@ -18074,8 +17221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Veininkatu 23",
-            "localadmin": "Espoo"
+            "name": "Veininkatu 23"
           }
         ],
         "coordinates": [
@@ -18095,8 +17241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähänlahdentie 10b",
-            "localadmin": "Espoo"
+            "name": "Vähänlahdentie 10b"
           }
         ],
         "coordinates": [
@@ -18116,8 +17261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähänlahdentie 22",
-            "localadmin": "Espoo"
+            "name": "Vähänlahdentie 22"
           }
         ],
         "coordinates": [
@@ -18137,8 +17281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yläkartanontie 22",
-            "localadmin": "Espoo"
+            "name": "Yläkartanontie 22"
           }
         ],
         "coordinates": [
@@ -18158,8 +17301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Markkinakatu 3",
-            "localadmin": "Espoo"
+            "name": "Markkinakatu 3"
           }
         ],
         "coordinates": [
@@ -18179,8 +17321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Takkatie 21",
-            "localadmin": "Espoo"
+            "name": "Takkatie 21"
           }
         ],
         "coordinates": [
@@ -18200,8 +17341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Miilumäki 7b",
-            "localadmin": "Espoo"
+            "name": "Miilumäki 7b"
           }
         ],
         "coordinates": [
@@ -18221,8 +17361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Bassenkyläntie 6",
-            "localadmin": "Espoo"
+            "name": "Bassenkyläntie 6"
           }
         ],
         "coordinates": [
@@ -18242,8 +17381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruusutorpanpuisto 5",
-            "localadmin": "Espoo"
+            "name": "Ruusutorpanpuisto 5"
           }
         ],
         "coordinates": [
@@ -18263,8 +17401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Isonkorventie 17",
-            "localadmin": "Espoo"
+            "name": "Isonkorventie 17"
           }
         ],
         "coordinates": [
@@ -18284,8 +17421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Martinniitty 6b",
-            "localadmin": "Espoo"
+            "name": "Martinniitty 6b"
           }
         ],
         "coordinates": [
@@ -18305,8 +17441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Painiityntie 23",
-            "localadmin": "Espoo"
+            "name": "Painiityntie 23"
           }
         ],
         "coordinates": [
@@ -18326,8 +17461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kemistintie 3",
-            "localadmin": "Espoo"
+            "name": "Kemistintie 3"
           }
         ],
         "coordinates": [
@@ -18347,8 +17481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivu-Mankkaan Tie 1b",
-            "localadmin": "Espoo"
+            "name": "Koivu-Mankkaan Tie 1b"
           }
         ],
         "coordinates": [
@@ -18368,8 +17501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nyppylätie 15",
-            "localadmin": "Espoo"
+            "name": "Nyppylätie 15"
           }
         ],
         "coordinates": [
@@ -18389,8 +17521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nihtisilta 4",
-            "localadmin": "Espoo"
+            "name": "Nihtisilta 4"
           }
         ],
         "coordinates": [
@@ -18410,8 +17541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurintie 20",
-            "localadmin": "Espoo"
+            "name": "Nupurintie 20"
           }
         ],
         "coordinates": [
@@ -18431,8 +17561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nahkasuutarintie 2",
-            "localadmin": "Espoo"
+            "name": "Nahkasuutarintie 2"
           }
         ],
         "coordinates": [
@@ -18452,8 +17581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Skataholmankuja 6",
-            "localadmin": "Espoo"
+            "name": "Skataholmankuja 6"
           }
         ],
         "coordinates": [
@@ -18473,8 +17601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirjomäki 21",
-            "localadmin": "Espoo"
+            "name": "Kirjomäki 21"
           }
         ],
         "coordinates": [
@@ -18494,8 +17621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Majamäentie 15",
-            "localadmin": "Espoo"
+            "name": "Majamäentie 15"
           }
         ],
         "coordinates": [
@@ -18515,8 +17641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Santapellonkuja 6",
-            "localadmin": "Espoo"
+            "name": "Santapellonkuja 6"
           }
         ],
         "coordinates": [
@@ -18536,8 +17661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Äyräpääntie 7a",
-            "localadmin": "Espoo"
+            "name": "Äyräpääntie 7a"
           }
         ],
         "coordinates": [
@@ -18557,8 +17681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivistontie 11",
-            "localadmin": "Espoo"
+            "name": "Koivistontie 11"
           }
         ],
         "coordinates": [
@@ -18578,8 +17701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkipuronkuja 10",
-            "localadmin": "Espoo"
+            "name": "Mäkipuronkuja 10"
           }
         ],
         "coordinates": [
@@ -18599,8 +17721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuohikuja 3",
-            "localadmin": "Espoo"
+            "name": "Tuohikuja 3"
           }
         ],
         "coordinates": [
@@ -18620,8 +17741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotiportinkuja 9",
-            "localadmin": "Espoo"
+            "name": "Kotiportinkuja 9"
           }
         ],
         "coordinates": [
@@ -18641,8 +17761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Riihiniityntie 17",
-            "localadmin": "Espoo"
+            "name": "Riihiniityntie 17"
           }
         ],
         "coordinates": [
@@ -18662,8 +17781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nauriskaski 10",
-            "localadmin": "Espoo"
+            "name": "Nauriskaski 10"
           }
         ],
         "coordinates": [
@@ -18683,8 +17801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pikku-Vehka 54",
-            "localadmin": "Espoo"
+            "name": "Pikku-Vehka 54"
           }
         ],
         "coordinates": [
@@ -18704,8 +17821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajapyörteentie 15",
-            "localadmin": "Espoo"
+            "name": "Rajapyörteentie 15"
           }
         ],
         "coordinates": [
@@ -18725,8 +17841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sumparen 38",
-            "localadmin": "Espoo"
+            "name": "Sumparen 38"
           }
         ],
         "coordinates": [
@@ -18746,8 +17861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkasaarenranta 10",
-            "localadmin": "Espoo"
+            "name": "Vehkasaarenranta 10"
           }
         ],
         "coordinates": [
@@ -18767,8 +17881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Opinkuja 4",
-            "localadmin": "Espoo"
+            "name": "Opinkuja 4"
           }
         ],
         "coordinates": [
@@ -18788,8 +17901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Åvallantie 6",
-            "localadmin": "Espoo"
+            "name": "Åvallantie 6"
           }
         ],
         "coordinates": [
@@ -18809,8 +17921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lepsämänjoentie 7",
-            "localadmin": "Espoo"
+            "name": "Lepsämänjoentie 7"
           }
         ],
         "coordinates": [
@@ -18830,8 +17941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäentie 12a",
-            "localadmin": "Espoo"
+            "name": "Perusmäentie 12a"
           }
         ],
         "coordinates": [
@@ -18851,8 +17961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Meriniemenpolku 4",
-            "localadmin": "Espoo"
+            "name": "Meriniemenpolku 4"
           }
         ],
         "coordinates": [
@@ -18872,8 +17981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Meriniemenpolku 3",
-            "localadmin": "Espoo"
+            "name": "Meriniemenpolku 3"
           }
         ],
         "coordinates": [
@@ -18893,8 +18001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pehtorintie 6",
-            "localadmin": "Espoo"
+            "name": "Pehtorintie 6"
           }
         ],
         "coordinates": [
@@ -18914,8 +18021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuhkurilammentie 16",
-            "localadmin": "Espoo"
+            "name": "Tuhkurilammentie 16"
           }
         ],
         "coordinates": [
@@ -18935,8 +18041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Juvanmalmintie 20",
-            "localadmin": "Espoo"
+            "name": "Juvanmalmintie 20"
           }
         ],
         "coordinates": [
@@ -18956,8 +18061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rastasniityntie 1",
-            "localadmin": "Espoo"
+            "name": "Rastasniityntie 1"
           }
         ],
         "coordinates": [
@@ -18977,8 +18081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kahdeksas Huvilatie 3",
-            "localadmin": "Espoo"
+            "name": "Kahdeksas Huvilatie 3"
           }
         ],
         "coordinates": [
@@ -18998,8 +18101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kattilantie 6",
-            "localadmin": "Espoo"
+            "name": "Kattilantie 6"
           }
         ],
         "coordinates": [
@@ -19019,8 +18121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Luukintie 15",
-            "localadmin": "Espoo"
+            "name": "Vanha Luukintie 15"
           }
         ],
         "coordinates": [
@@ -19040,8 +18141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsämaantie 20",
-            "localadmin": "Espoo"
+            "name": "Metsämaantie 20"
           }
         ],
         "coordinates": [
@@ -19061,8 +18161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suolaakso 8",
-            "localadmin": "Espoo"
+            "name": "Suolaakso 8"
           }
         ],
         "coordinates": [
@@ -19082,8 +18181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Mariannantie 36",
-            "localadmin": "Espoo"
+            "name": "Mariannantie 36"
           }
         ],
         "coordinates": [
@@ -19103,8 +18201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalajärventie 36",
-            "localadmin": "Espoo"
+            "name": "Kalajärventie 36"
           }
         ],
         "coordinates": [
@@ -19124,8 +18221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurkikuja 2",
-            "localadmin": "Espoo"
+            "name": "Kurkikuja 2"
           }
         ],
         "coordinates": [
@@ -19145,8 +18241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Elisantie 17",
-            "localadmin": "Espoo"
+            "name": "Elisantie 17"
           }
         ],
         "coordinates": [
@@ -19166,8 +18261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ståhlentie 7",
-            "localadmin": "Espoo"
+            "name": "Ståhlentie 7"
           }
         ],
         "coordinates": [
@@ -19187,8 +18281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Alaniementie 6",
-            "localadmin": "Espoo"
+            "name": "Alaniementie 6"
           }
         ],
         "coordinates": [
@@ -19208,8 +18301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suolaaksontie 19",
-            "localadmin": "Espoo"
+            "name": "Suolaaksontie 19"
           }
         ],
         "coordinates": [
@@ -19229,8 +18321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suolaaksontie 22",
-            "localadmin": "Espoo"
+            "name": "Suolaaksontie 22"
           }
         ],
         "coordinates": [
@@ -19250,8 +18341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Lahnuksentie 26",
-            "localadmin": "Espoo"
+            "name": "Vanha Lahnuksentie 26"
           }
         ],
         "coordinates": [
@@ -19271,8 +18361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ämmänkalliontie 3",
-            "localadmin": "Espoo"
+            "name": "Ämmänkalliontie 3"
           }
         ],
         "coordinates": [
@@ -19292,8 +18381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suopuronniitty 10",
-            "localadmin": "Espoo"
+            "name": "Suopuronniitty 10"
           }
         ],
         "coordinates": [
@@ -19313,8 +18401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lammenranta 10",
-            "localadmin": "Espoo"
+            "name": "Lammenranta 10"
           }
         ],
         "coordinates": [
@@ -19334,8 +18421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivumäentie 13a",
-            "localadmin": "Espoo"
+            "name": "Koivumäentie 13a"
           }
         ],
         "coordinates": [
@@ -19355,8 +18441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivumäentie 7",
-            "localadmin": "Espoo"
+            "name": "Koivumäentie 7"
           }
         ],
         "coordinates": [
@@ -19376,8 +18461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Purometsä 9",
-            "localadmin": "Espoo"
+            "name": "Purometsä 9"
           }
         ],
         "coordinates": [
@@ -19397,8 +18481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuuksiontie 52c",
-            "localadmin": "Espoo"
+            "name": "Nuuksiontie 52c"
           }
         ],
         "coordinates": [
@@ -19418,8 +18501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Maarinpuro 11b",
-            "localadmin": "Espoo"
+            "name": "Maarinpuro 11b"
           }
         ],
         "coordinates": [
@@ -19439,8 +18521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Juvanniitty 2",
-            "localadmin": "Espoo"
+            "name": "Juvanniitty 2"
           }
         ],
         "coordinates": [
@@ -19460,8 +18541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylvötie 9b",
-            "localadmin": "Espoo"
+            "name": "Kylvötie 9b"
           }
         ],
         "coordinates": [
@@ -19481,8 +18561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylvötie 13b",
-            "localadmin": "Espoo"
+            "name": "Kylvötie 13b"
           }
         ],
         "coordinates": [
@@ -19502,8 +18581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Heinäslammentie 15",
-            "localadmin": "Espoo"
+            "name": "Heinäslammentie 15"
           }
         ],
         "coordinates": [
@@ -19523,8 +18601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vilhelmintie 23",
-            "localadmin": "Espoo"
+            "name": "Vilhelmintie 23"
           }
         ],
         "coordinates": [
@@ -19544,8 +18621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Juvanniitty 12",
-            "localadmin": "Espoo"
+            "name": "Juvanniitty 12"
           }
         ],
         "coordinates": [
@@ -19565,8 +18641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Onninkuja 3",
-            "localadmin": "Espoo"
+            "name": "Onninkuja 3"
           }
         ],
         "coordinates": [
@@ -19586,8 +18661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Purolehto 35",
-            "localadmin": "Espoo"
+            "name": "Purolehto 35"
           }
         ],
         "coordinates": [
@@ -19607,8 +18681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäenkuja 2",
-            "localadmin": "Espoo"
+            "name": "Perusmäenkuja 2"
           }
         ],
         "coordinates": [
@@ -19628,8 +18701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivumäentie 13b",
-            "localadmin": "Espoo"
+            "name": "Koivumäentie 13b"
           }
         ],
         "coordinates": [
@@ -19649,8 +18721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suolaaksontie 12a",
-            "localadmin": "Espoo"
+            "name": "Suolaaksontie 12a"
           }
         ],
         "coordinates": [
@@ -19670,8 +18741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuohikallio 8",
-            "localadmin": "Espoo"
+            "name": "Vuohikallio 8"
           }
         ],
         "coordinates": [
@@ -19691,8 +18761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Huvilarinne 23",
-            "localadmin": "Espoo"
+            "name": "Huvilarinne 23"
           }
         ],
         "coordinates": [
@@ -19712,8 +18781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Koskelontie 20",
-            "localadmin": "Espoo"
+            "name": "Koskelontie 20"
           }
         ],
         "coordinates": [
@@ -19733,8 +18801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pehtorinkuja 5",
-            "localadmin": "Espoo"
+            "name": "Pehtorinkuja 5"
           }
         ],
         "coordinates": [
@@ -19754,8 +18821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nummikuja 19",
-            "localadmin": "Espoo"
+            "name": "Nummikuja 19"
           }
         ],
         "coordinates": [
@@ -19775,8 +18841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Yhteistuvantie 8b",
-            "localadmin": "Espoo"
+            "name": "Yhteistuvantie 8b"
           }
         ],
         "coordinates": [
@@ -19796,8 +18861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Brobackantie 39",
-            "localadmin": "Espoo"
+            "name": "Brobackantie 39"
           }
         ],
         "coordinates": [
@@ -19817,8 +18881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakjärventie 2a",
-            "localadmin": "Espoo"
+            "name": "Hakjärventie 2a"
           }
         ],
         "coordinates": [
@@ -19838,8 +18901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sävelkaari 6",
-            "localadmin": "Espoo"
+            "name": "Sävelkaari 6"
           }
         ],
         "coordinates": [
@@ -19859,8 +18921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalkkikuja 9",
-            "localadmin": "Espoo"
+            "name": "Kalkkikuja 9"
           }
         ],
         "coordinates": [
@@ -19880,8 +18941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruispellontie 7",
-            "localadmin": "Espoo"
+            "name": "Ruispellontie 7"
           }
         ],
         "coordinates": [
@@ -19901,8 +18961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäjärvenranta 20",
-            "localadmin": "Espoo"
+            "name": "Pitkäjärvenranta 20"
           }
         ],
         "coordinates": [
@@ -19922,8 +18981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmperäntie 18",
-            "localadmin": "Espoo"
+            "name": "Kolmperäntie 18"
           }
         ],
         "coordinates": [
@@ -19943,8 +19001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmperänrinne 6",
-            "localadmin": "Espoo"
+            "name": "Kolmperänrinne 6"
           }
         ],
         "coordinates": [
@@ -19964,8 +19021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Punarinnantie 3",
-            "localadmin": "Espoo"
+            "name": "Punarinnantie 3"
           }
         ],
         "coordinates": [
@@ -19985,8 +19041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leppärousku 10",
-            "localadmin": "Espoo"
+            "name": "Leppärousku 10"
           }
         ],
         "coordinates": [
@@ -20006,8 +19061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuusinevantie 20",
-            "localadmin": "Espoo"
+            "name": "Kuusinevantie 20"
           }
         ],
         "coordinates": [
@@ -20027,8 +19081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Luuvantie 2",
-            "localadmin": "Espoo"
+            "name": "Luuvantie 2"
           }
         ],
         "coordinates": [
@@ -20048,8 +19101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Tallipojankuja 3",
-            "localadmin": "Espoo"
+            "name": "Tallipojankuja 3"
           }
         ],
         "coordinates": [
@@ -20069,8 +19121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ukinpolku 20",
-            "localadmin": "Espoo"
+            "name": "Ukinpolku 20"
           }
         ],
         "coordinates": [
@@ -20090,8 +19141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lähderanta 2",
-            "localadmin": "Espoo"
+            "name": "Lähderanta 2"
           }
         ],
         "coordinates": [
@@ -20111,8 +19161,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ämmässuonkuja 4",
-            "localadmin": "Espoo"
+            "name": "Ämmässuonkuja 4"
           }
         ],
         "coordinates": [
@@ -20132,8 +19181,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotilastorpantie 22",
-            "localadmin": "Espoo"
+            "name": "Sotilastorpantie 22"
           }
         ],
         "coordinates": [
@@ -20153,8 +19201,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hovileipurinkuja 2",
-            "localadmin": "Espoo"
+            "name": "Hovileipurinkuja 2"
           }
         ],
         "coordinates": [
@@ -20174,8 +19221,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehrääjäntie 21",
-            "localadmin": "Espoo"
+            "name": "Kehrääjäntie 21"
           }
         ],
         "coordinates": [
@@ -20195,8 +19241,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinirinnantie 11",
-            "localadmin": "Espoo"
+            "name": "Sinirinnantie 11"
           }
         ],
         "coordinates": [
@@ -20216,8 +19261,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintuvaarantie 39",
-            "localadmin": "Espoo"
+            "name": "Lintuvaarantie 39"
           }
         ],
         "coordinates": [
@@ -20237,8 +19281,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Peipontie 17a",
-            "localadmin": "Espoo"
+            "name": "Peipontie 17a"
           }
         ],
         "coordinates": [
@@ -20258,8 +19301,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiurunkuja 1",
-            "localadmin": "Espoo"
+            "name": "Kiurunkuja 1"
           }
         ],
         "coordinates": [
@@ -20279,8 +19321,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Viserrystie 8a",
-            "localadmin": "Espoo"
+            "name": "Viserrystie 8a"
           }
         ],
         "coordinates": [
@@ -20300,8 +19341,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakastiaisenkuja 1",
-            "localadmin": "Espoo"
+            "name": "Pakastiaisenkuja 1"
           }
         ],
         "coordinates": [
@@ -20321,8 +19361,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakastiaisenkuja 3b",
-            "localadmin": "Espoo"
+            "name": "Pakastiaisenkuja 3b"
           }
         ],
         "coordinates": [
@@ -20342,8 +19381,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Punavarpusentie 5",
-            "localadmin": "Espoo"
+            "name": "Punavarpusentie 5"
           }
         ],
         "coordinates": [
@@ -20363,8 +19401,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Rastasniityntie 23",
-            "localadmin": "Espoo"
+            "name": "Rastasniityntie 23"
           }
         ],
         "coordinates": [
@@ -20384,8 +19421,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pajuviita 5",
-            "localadmin": "Espoo"
+            "name": "Pajuviita 5"
           }
         ],
         "coordinates": [
@@ -20405,8 +19441,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhuniityntie 20a",
-            "localadmin": "Espoo"
+            "name": "Karhuniityntie 20a"
           }
         ],
         "coordinates": [
@@ -20426,8 +19461,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Heiniemi 13",
-            "localadmin": "Espoo"
+            "name": "Heiniemi 13"
           }
         ],
         "coordinates": [
@@ -20447,8 +19481,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Heiniemi 2b",
-            "localadmin": "Espoo"
+            "name": "Heiniemi 2b"
           }
         ],
         "coordinates": [
@@ -20468,8 +19501,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kylänportti 2",
-            "localadmin": "Espoo"
+            "name": "Kylänportti 2"
           }
         ],
         "coordinates": [
@@ -20489,8 +19521,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nostoväenkuja 1",
-            "localadmin": "Espoo"
+            "name": "Nostoväenkuja 1"
           }
         ],
         "coordinates": [
@@ -20510,8 +19541,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kakkostie 5",
-            "localadmin": "Espoo"
+            "name": "Kakkostie 5"
           }
         ],
         "coordinates": [
@@ -20531,8 +19561,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Veikkaustie 10",
-            "localadmin": "Espoo"
+            "name": "Veikkaustie 10"
           }
         ],
         "coordinates": [
@@ -20552,8 +19581,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karakalliontie 12",
-            "localadmin": "Espoo"
+            "name": "Karakalliontie 12"
           }
         ],
         "coordinates": [
@@ -20573,8 +19601,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Jahtimestarinkuja 2",
-            "localadmin": "Espoo"
+            "name": "Jahtimestarinkuja 2"
           }
         ],
         "coordinates": [
@@ -20594,8 +19621,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Myllypadontie 4",
-            "localadmin": "Espoo"
+            "name": "Myllypadontie 4"
           }
         ],
         "coordinates": [
@@ -20615,8 +19641,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhunkuoppa 6",
-            "localadmin": "Espoo"
+            "name": "Karhunkuoppa 6"
           }
         ],
         "coordinates": [
@@ -20636,8 +19661,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Timpurinkuja 2",
-            "localadmin": "Espoo"
+            "name": "Timpurinkuja 2"
           }
         ],
         "coordinates": [
@@ -20657,8 +19681,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Porarinkatu 10",
-            "localadmin": "Espoo"
+            "name": "Porarinkatu 10"
           }
         ],
         "coordinates": [
@@ -20678,8 +19701,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurinrinne 11",
-            "localadmin": "Espoo"
+            "name": "Nupurinrinne 11"
           }
         ],
         "coordinates": [
@@ -20699,8 +19721,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallikallionkuja 6",
-            "localadmin": "Espoo"
+            "name": "Vallikallionkuja 6"
           }
         ],
         "coordinates": [
@@ -20720,8 +19741,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kavallinmäki 14",
-            "localadmin": "Espoo"
+            "name": "Kavallinmäki 14"
           }
         ],
         "coordinates": [
@@ -20741,8 +19761,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Suohaukantie 2",
-            "localadmin": "Espoo"
+            "name": "Suohaukantie 2"
           }
         ],
         "coordinates": [
@@ -20762,8 +19781,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Patokuja 4",
-            "localadmin": "Espoo"
+            "name": "Patokuja 4"
           }
         ],
         "coordinates": [
@@ -20783,8 +19801,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Sysimaa 6",
-            "localadmin": "Espoo"
+            "name": "Sysimaa 6"
           }
         ],
         "coordinates": [
@@ -20804,8 +19821,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurutie 17",
-            "localadmin": "Espoo"
+            "name": "Kurutie 17"
           }
         ],
         "coordinates": [
@@ -20825,8 +19841,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Riistatie 5",
-            "localadmin": "Espoo"
+            "name": "Riistatie 5"
           }
         ],
         "coordinates": [
@@ -20846,8 +19861,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruusutorpankuja 3",
-            "localadmin": "Espoo"
+            "name": "Ruusutorpankuja 3"
           }
         ],
         "coordinates": [
@@ -20867,8 +19881,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pikkukouluntie 5",
-            "localadmin": "Espoo"
+            "name": "Pikkukouluntie 5"
           }
         ],
         "coordinates": [
@@ -20888,8 +19901,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirvikuja 10",
-            "localadmin": "Espoo"
+            "name": "Hirvikuja 10"
           }
         ],
         "coordinates": [
@@ -20909,8 +19921,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ritarintie 8",
-            "localadmin": "Espoo"
+            "name": "Ritarintie 8"
           }
         ],
         "coordinates": [
@@ -20930,8 +19941,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Lautamiehentie 3",
-            "localadmin": "Espoo"
+            "name": "Lautamiehentie 3"
           }
         ],
         "coordinates": [
@@ -20951,8 +19961,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Miilukorventie 2",
-            "localadmin": "Espoo"
+            "name": "Miilukorventie 2"
           }
         ],
         "coordinates": [
@@ -20972,8 +19981,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilonkuja 3",
-            "localadmin": "Espoo"
+            "name": "Kilonkuja 3"
           }
         ],
         "coordinates": [
@@ -20993,8 +20001,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilpitie 1",
-            "localadmin": "Espoo"
+            "name": "Kilpitie 1"
           }
         ],
         "coordinates": [
@@ -21014,8 +20021,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäniityntie 8",
-            "localadmin": "Espoo"
+            "name": "Pitkäniityntie 8"
           }
         ],
         "coordinates": [
@@ -21035,8 +20041,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säterinkatu 29",
-            "localadmin": "Espoo"
+            "name": "Säterinkatu 29"
           }
         ],
         "coordinates": [
@@ -21056,8 +20061,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Säterinkatu 10",
-            "localadmin": "Espoo"
+            "name": "Säterinkatu 10"
           }
         ],
         "coordinates": [
@@ -21077,8 +20081,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Majurinkatu 1",
-            "localadmin": "Espoo"
+            "name": "Majurinkatu 1"
           }
         ],
         "coordinates": [
@@ -21098,8 +20101,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruusutorpankuja 4",
-            "localadmin": "Espoo"
+            "name": "Ruusutorpankuja 4"
           }
         ],
         "coordinates": [
@@ -21119,8 +20121,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Leirikaari 20",
-            "localadmin": "Espoo"
+            "name": "Leirikaari 20"
           }
         ],
         "coordinates": [
@@ -21140,8 +20141,7 @@
       "expected": {
         "properties": [
           {
-            "name": "Ymmerstanmäki 9a",
-            "localadmin": "Espoo"
+            "name": "Ymmerstanmäki 9a"
           }
         ],
         "coordinates": [

--- a/test_cases/HslPoiTest.json
+++ b/test_cases/HslPoiTest.json
@@ -21,7 +21,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -43,7 +42,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -65,7 +63,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -87,7 +84,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -109,7 +105,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -131,7 +126,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -153,7 +147,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -175,7 +168,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -197,7 +189,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -219,7 +210,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -241,7 +231,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -263,7 +252,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -285,7 +273,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -307,7 +294,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -329,7 +315,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -351,7 +336,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -373,7 +357,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -395,7 +378,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -417,7 +399,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -439,7 +420,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -461,7 +441,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -483,7 +462,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -505,7 +483,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -527,7 +504,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -549,7 +525,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -571,7 +546,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -593,7 +567,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -615,7 +588,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -637,7 +609,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -659,7 +630,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -681,7 +651,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -703,7 +672,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -725,7 +693,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -747,7 +714,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -769,7 +735,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -791,7 +756,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -813,7 +777,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -835,7 +798,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -857,7 +819,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -879,7 +840,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -901,7 +861,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -923,7 +882,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -945,7 +903,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -967,7 +924,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -989,7 +945,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1011,7 +966,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1033,7 +987,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1055,7 +1008,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1077,7 +1029,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1099,7 +1050,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1121,7 +1071,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1143,7 +1092,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1165,7 +1113,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1187,7 +1134,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1209,7 +1155,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1231,7 +1176,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1253,7 +1197,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1275,7 +1218,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1297,7 +1239,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1319,7 +1260,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1341,7 +1281,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1363,7 +1302,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1385,7 +1323,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1407,7 +1344,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1429,7 +1365,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1451,7 +1386,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1473,7 +1407,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1495,7 +1428,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1517,7 +1449,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1539,7 +1470,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1561,7 +1491,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1583,7 +1512,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1605,7 +1533,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1627,7 +1554,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1649,7 +1575,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1671,7 +1596,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1693,7 +1617,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1715,7 +1638,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1737,7 +1659,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1759,7 +1680,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1781,7 +1701,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1803,7 +1722,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1825,7 +1743,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1847,7 +1764,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1869,7 +1785,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1891,7 +1806,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1913,7 +1827,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1935,7 +1848,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1957,7 +1869,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -1979,7 +1890,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2001,7 +1911,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2023,7 +1932,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2045,7 +1953,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2067,7 +1974,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2089,7 +1995,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2111,7 +2016,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2133,7 +2037,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2155,7 +2058,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2177,7 +2079,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2199,7 +2100,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2221,7 +2121,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2243,7 +2142,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2265,7 +2163,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2287,7 +2184,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2309,7 +2205,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2331,7 +2226,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2353,7 +2247,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2375,7 +2268,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2397,7 +2289,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2419,7 +2310,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2441,7 +2331,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2463,7 +2352,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2485,7 +2373,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2507,7 +2394,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2529,7 +2415,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2551,7 +2436,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2573,7 +2457,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2595,7 +2478,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2617,7 +2499,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2639,7 +2520,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2661,7 +2541,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2683,7 +2562,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2705,7 +2583,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2727,7 +2604,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2749,7 +2625,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2771,7 +2646,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2793,7 +2667,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2815,7 +2688,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2837,7 +2709,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2859,7 +2730,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -2881,7 +2751,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2903,7 +2772,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2925,7 +2793,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2947,7 +2814,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -2969,7 +2835,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -2991,7 +2856,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3013,7 +2877,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3035,7 +2898,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3057,7 +2919,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3079,7 +2940,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3101,7 +2961,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3123,7 +2982,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3145,7 +3003,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3167,7 +3024,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3189,7 +3045,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3211,7 +3066,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3233,7 +3087,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3255,7 +3108,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3277,7 +3129,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3299,7 +3150,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3321,7 +3171,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3343,7 +3192,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3365,7 +3213,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3387,7 +3234,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3409,7 +3255,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3431,7 +3276,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3453,7 +3297,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3475,7 +3318,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3497,7 +3339,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3519,7 +3360,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3541,7 +3381,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3563,7 +3402,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3585,7 +3423,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3607,7 +3444,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3629,7 +3465,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3651,7 +3486,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3673,7 +3507,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3695,7 +3528,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -3717,7 +3549,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3739,7 +3570,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3761,7 +3591,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3783,7 +3612,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3805,7 +3633,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3827,7 +3654,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3849,7 +3675,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3871,7 +3696,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3893,7 +3717,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -3915,7 +3738,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -3937,7 +3759,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -3959,7 +3780,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -3981,7 +3801,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4003,7 +3822,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4025,7 +3843,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4047,7 +3864,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4069,7 +3885,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4091,7 +3906,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4113,7 +3927,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4135,7 +3948,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4157,7 +3969,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4179,7 +3990,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4201,7 +4011,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4223,7 +4032,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4245,7 +4053,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -4267,7 +4074,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4289,7 +4095,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4311,7 +4116,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4333,7 +4137,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4355,7 +4158,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4377,7 +4179,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -4399,7 +4200,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4421,7 +4221,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4443,7 +4242,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4465,7 +4263,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4487,7 +4284,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4509,7 +4305,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4531,7 +4326,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4553,7 +4347,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4575,7 +4368,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4597,7 +4389,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4619,7 +4410,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4641,7 +4431,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4663,7 +4452,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4685,7 +4473,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4707,7 +4494,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4729,7 +4515,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4751,7 +4536,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4773,7 +4557,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4795,7 +4578,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4817,7 +4599,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4839,7 +4620,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4861,7 +4641,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4883,7 +4662,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4905,7 +4683,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4927,7 +4704,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4949,7 +4725,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4971,7 +4746,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -4993,7 +4767,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5015,7 +4788,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5037,7 +4809,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5059,7 +4830,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5081,7 +4851,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5103,7 +4872,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5125,7 +4893,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5147,7 +4914,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5169,7 +4935,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5191,7 +4956,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5213,7 +4977,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5235,7 +4998,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -5257,7 +5019,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5279,7 +5040,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5301,7 +5061,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5323,7 +5082,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5345,7 +5103,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5367,7 +5124,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5389,7 +5145,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5411,7 +5166,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5433,7 +5187,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5455,7 +5208,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5477,7 +5229,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5499,7 +5250,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5521,7 +5271,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5543,7 +5292,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5565,7 +5313,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5587,7 +5334,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5609,7 +5355,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5631,7 +5376,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5653,7 +5397,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5675,7 +5418,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5697,7 +5439,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5719,7 +5460,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5741,7 +5481,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5763,7 +5502,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5785,7 +5523,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5807,7 +5544,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5829,7 +5565,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5851,7 +5586,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5873,7 +5607,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5895,7 +5628,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5917,7 +5649,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5939,7 +5670,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5961,7 +5691,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -5983,7 +5712,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6005,7 +5733,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6027,7 +5754,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6049,7 +5775,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6071,7 +5796,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6093,7 +5817,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6115,7 +5838,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6137,7 +5859,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6159,7 +5880,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6181,7 +5901,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6203,7 +5922,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6225,7 +5943,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6247,7 +5964,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6269,7 +5985,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -6291,7 +6006,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -6313,7 +6027,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6335,7 +6048,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6357,7 +6069,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6379,7 +6090,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6401,7 +6111,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6423,7 +6132,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6445,7 +6153,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6467,7 +6174,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6489,7 +6195,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6511,7 +6216,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6533,7 +6237,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6555,7 +6258,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6577,7 +6279,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6599,7 +6300,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6621,7 +6321,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6643,7 +6342,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6665,7 +6363,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6687,7 +6384,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6709,7 +6405,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6731,7 +6426,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6753,7 +6447,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6775,7 +6468,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6797,7 +6489,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6819,7 +6510,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6841,7 +6531,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6863,7 +6552,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6885,7 +6573,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -6907,7 +6594,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6929,7 +6615,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -6951,7 +6636,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6973,7 +6657,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -6995,7 +6678,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7017,7 +6699,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7039,7 +6720,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7061,7 +6741,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7083,7 +6762,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7105,7 +6783,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7127,7 +6804,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7149,7 +6825,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7171,7 +6846,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7193,7 +6867,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7215,7 +6888,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7237,7 +6909,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7259,7 +6930,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7281,7 +6951,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7303,7 +6972,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7325,7 +6993,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7347,7 +7014,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7369,7 +7035,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7391,7 +7056,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7413,7 +7077,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7435,7 +7098,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7457,7 +7119,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7479,7 +7140,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7501,7 +7161,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7523,7 +7182,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7545,7 +7203,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7567,7 +7224,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7589,7 +7245,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7611,7 +7266,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7633,7 +7287,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7655,7 +7308,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7677,7 +7329,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7699,7 +7350,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7721,7 +7371,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7743,7 +7392,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7765,7 +7413,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7787,7 +7434,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7809,7 +7455,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7831,7 +7476,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7853,7 +7497,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7875,7 +7518,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7897,7 +7539,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -7919,7 +7560,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7941,7 +7581,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -7963,7 +7602,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -7985,7 +7623,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8007,7 +7644,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8029,7 +7665,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8051,7 +7686,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8073,7 +7707,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8095,7 +7728,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8117,7 +7749,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8139,7 +7770,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8161,7 +7791,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8183,7 +7812,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8205,7 +7833,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8227,7 +7854,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8249,7 +7875,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -8271,7 +7896,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -8293,7 +7917,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8315,7 +7938,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8337,7 +7959,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8359,7 +7980,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8381,7 +8001,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8403,7 +8022,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8425,7 +8043,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8447,7 +8064,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8469,7 +8085,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8491,7 +8106,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8513,7 +8127,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8535,7 +8148,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8557,7 +8169,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8579,7 +8190,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8601,7 +8211,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8623,7 +8232,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8645,7 +8253,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8667,7 +8274,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8689,7 +8295,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8711,7 +8316,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8733,7 +8337,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8755,7 +8358,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8777,7 +8379,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8799,7 +8400,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -8821,7 +8421,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8843,7 +8442,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8865,7 +8463,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -8887,7 +8484,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8909,7 +8505,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8931,7 +8526,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8953,7 +8547,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8975,7 +8568,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -8997,7 +8589,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9019,7 +8610,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9041,7 +8631,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9063,7 +8652,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9085,7 +8673,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9107,7 +8694,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9129,7 +8715,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9151,7 +8736,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9173,7 +8757,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9195,7 +8778,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9217,7 +8799,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9239,7 +8820,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9261,7 +8841,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9283,7 +8862,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9305,7 +8883,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9327,7 +8904,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9349,7 +8925,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9371,7 +8946,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9393,7 +8967,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9415,7 +8988,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9437,7 +9009,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9459,7 +9030,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9481,7 +9051,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9503,7 +9072,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9525,7 +9093,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9547,7 +9114,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9569,7 +9135,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9591,7 +9156,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9613,7 +9177,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9635,7 +9198,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9657,7 +9219,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9679,7 +9240,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9701,7 +9261,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9723,7 +9282,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9745,7 +9303,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9767,7 +9324,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9789,7 +9345,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9811,7 +9366,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -9833,7 +9387,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9855,7 +9408,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9877,7 +9429,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9899,7 +9450,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9921,7 +9471,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9943,7 +9492,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9965,7 +9513,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -9987,7 +9534,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10009,7 +9555,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10031,7 +9576,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10053,7 +9597,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10075,7 +9618,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10097,7 +9639,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10119,7 +9660,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10141,7 +9681,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10163,7 +9702,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10185,7 +9723,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10207,7 +9744,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10229,7 +9765,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10251,7 +9786,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10273,7 +9807,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10295,7 +9828,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10317,7 +9849,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10339,7 +9870,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10361,7 +9891,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10383,7 +9912,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10405,7 +9933,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10427,7 +9954,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10449,7 +9975,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10471,7 +9996,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10493,7 +10017,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10515,7 +10038,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10537,7 +10059,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10559,7 +10080,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10581,7 +10101,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10603,7 +10122,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10625,7 +10143,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10647,7 +10164,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10669,7 +10185,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10691,7 +10206,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10713,7 +10227,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10735,7 +10248,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10757,7 +10269,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10779,7 +10290,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10801,7 +10311,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10823,7 +10332,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10845,7 +10353,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10867,7 +10374,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10889,7 +10395,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10911,7 +10416,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10933,7 +10437,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10955,7 +10458,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10977,7 +10479,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -10999,7 +10500,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11021,7 +10521,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11043,7 +10542,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11065,7 +10563,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11087,7 +10584,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11109,7 +10605,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11131,7 +10626,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11153,7 +10647,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11175,7 +10668,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11197,7 +10689,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11219,7 +10710,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11241,7 +10731,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11263,7 +10752,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11285,7 +10773,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11307,7 +10794,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11329,7 +10815,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11351,7 +10836,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11373,7 +10857,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11395,7 +10878,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11417,7 +10899,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11439,7 +10920,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11461,7 +10941,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11483,7 +10962,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11505,7 +10983,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11527,7 +11004,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11549,7 +11025,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11571,7 +11046,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11593,7 +11067,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11615,7 +11088,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11637,7 +11109,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11659,7 +11130,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11681,7 +11151,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11703,7 +11172,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11725,7 +11193,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11747,7 +11214,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11769,7 +11235,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11791,7 +11256,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11813,7 +11277,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11835,7 +11298,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11857,7 +11319,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11879,7 +11340,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11901,7 +11361,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11923,7 +11382,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11945,7 +11403,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11967,7 +11424,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -11989,7 +11445,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12011,7 +11466,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12033,7 +11487,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12055,7 +11508,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12077,7 +11529,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12099,7 +11550,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12121,7 +11571,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12143,7 +11592,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12165,7 +11613,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12187,7 +11634,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12209,7 +11655,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12231,7 +11676,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12253,7 +11697,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12275,7 +11718,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12297,7 +11739,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12319,7 +11760,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12341,7 +11781,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12363,7 +11802,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12385,7 +11823,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12407,7 +11844,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12429,7 +11865,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12451,7 +11886,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12473,7 +11907,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12495,7 +11928,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12517,7 +11949,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12539,7 +11970,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12561,7 +11991,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12583,7 +12012,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12605,7 +12033,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12627,7 +12054,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12649,7 +12075,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12671,7 +12096,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12693,7 +12117,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12715,7 +12138,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -12737,7 +12159,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12759,7 +12180,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12781,7 +12201,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12803,7 +12222,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12825,7 +12243,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12847,7 +12264,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12869,7 +12285,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12891,7 +12306,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12913,7 +12327,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12935,7 +12348,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -12957,7 +12369,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -12979,7 +12390,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13001,7 +12411,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13023,7 +12432,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13045,7 +12453,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13067,7 +12474,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13089,7 +12495,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13111,7 +12516,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13133,7 +12537,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13155,7 +12558,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13177,7 +12579,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13199,7 +12600,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13221,7 +12621,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13243,7 +12642,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13265,7 +12663,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13287,7 +12684,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13309,7 +12705,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13331,7 +12726,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13353,7 +12747,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13375,7 +12768,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13397,7 +12789,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13419,7 +12810,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13441,7 +12831,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13463,7 +12852,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13485,7 +12873,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13507,7 +12894,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13529,7 +12915,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13551,7 +12936,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13573,7 +12957,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13595,7 +12978,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13617,7 +12999,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13639,7 +13020,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13661,7 +13041,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13683,7 +13062,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13705,7 +13083,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13727,7 +13104,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13749,7 +13125,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13771,7 +13146,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -13793,7 +13167,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13815,7 +13188,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13837,7 +13209,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -13859,7 +13230,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13881,7 +13251,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13903,7 +13272,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13925,7 +13293,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -13947,7 +13314,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13969,7 +13335,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -13991,7 +13356,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14013,7 +13377,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14035,7 +13398,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14057,7 +13419,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14079,7 +13440,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14101,7 +13461,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14123,7 +13482,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14145,7 +13503,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14167,7 +13524,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14189,7 +13545,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14211,7 +13566,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14233,7 +13587,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14255,7 +13608,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14277,7 +13629,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14299,7 +13650,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14321,7 +13671,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14343,7 +13692,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14365,7 +13713,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14387,7 +13734,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14409,7 +13755,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14431,7 +13776,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14453,7 +13797,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14475,7 +13818,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14497,7 +13839,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -14519,7 +13860,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14541,7 +13881,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14563,7 +13902,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14585,7 +13923,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14607,7 +13944,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -14629,7 +13965,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14651,7 +13986,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14673,7 +14007,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -14695,7 +14028,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14717,7 +14049,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14739,7 +14070,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14761,7 +14091,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14783,7 +14112,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14805,7 +14133,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14827,7 +14154,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14849,7 +14175,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14871,7 +14196,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14893,7 +14217,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14915,7 +14238,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14937,7 +14259,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14959,7 +14280,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -14981,7 +14301,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15003,7 +14322,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15025,7 +14343,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15047,7 +14364,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15069,7 +14385,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15091,7 +14406,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15113,7 +14427,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15135,7 +14448,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15157,7 +14469,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15179,7 +14490,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15201,7 +14511,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15223,7 +14532,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15245,7 +14553,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15267,7 +14574,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15289,7 +14595,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15311,7 +14616,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15333,7 +14637,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15355,7 +14658,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15377,7 +14679,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -15399,7 +14700,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -15421,7 +14721,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15443,7 +14742,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15465,7 +14763,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15487,7 +14784,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15509,7 +14805,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15531,7 +14826,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15553,7 +14847,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15575,7 +14868,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15597,7 +14889,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15619,7 +14910,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15641,7 +14931,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15663,7 +14952,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15685,7 +14973,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15707,7 +14994,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -15729,7 +15015,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15751,7 +15036,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15773,7 +15057,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15795,7 +15078,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15817,7 +15099,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15839,7 +15120,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15861,7 +15141,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15883,7 +15162,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15905,7 +15183,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -15927,7 +15204,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15949,7 +15225,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15971,7 +15246,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -15993,7 +15267,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16015,7 +15288,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16037,7 +15309,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16059,7 +15330,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16081,7 +15351,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16103,7 +15372,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16125,7 +15393,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16147,7 +15414,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16169,7 +15435,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16191,7 +15456,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16213,7 +15477,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16235,7 +15498,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16257,7 +15519,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16279,7 +15540,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16301,7 +15561,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16323,7 +15582,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16345,7 +15603,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16367,7 +15624,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16389,7 +15645,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16411,7 +15666,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16433,7 +15687,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16455,7 +15708,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16477,7 +15729,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16499,7 +15750,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16521,7 +15771,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16543,7 +15792,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16565,7 +15813,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16587,7 +15834,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16609,7 +15855,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16631,7 +15876,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16653,7 +15897,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16675,7 +15918,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16697,7 +15939,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16719,7 +15960,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16741,7 +15981,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16763,7 +16002,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16785,7 +16023,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16807,7 +16044,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16829,7 +16065,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16851,7 +16086,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16873,7 +16107,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16895,7 +16128,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16917,7 +16149,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16939,7 +16170,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16961,7 +16191,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -16983,7 +16212,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17005,7 +16233,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17027,7 +16254,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17049,7 +16275,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17071,7 +16296,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17093,7 +16317,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17115,7 +16338,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17137,7 +16359,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17159,7 +16380,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17181,7 +16401,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17203,7 +16422,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17225,7 +16443,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17247,7 +16464,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17269,7 +16485,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17291,7 +16506,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17313,7 +16527,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17335,7 +16548,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17357,7 +16569,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17379,7 +16590,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17401,7 +16611,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17423,7 +16632,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17445,7 +16653,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17467,7 +16674,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17489,7 +16695,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17511,7 +16716,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17533,7 +16737,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17555,7 +16758,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17577,7 +16779,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17599,7 +16800,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17621,7 +16821,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17643,7 +16842,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17665,7 +16863,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17687,7 +16884,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17709,7 +16905,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17731,7 +16926,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17753,7 +16947,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17775,7 +16968,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17797,7 +16989,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17819,7 +17010,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17841,7 +17031,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17863,7 +17052,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17885,7 +17073,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17907,7 +17094,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17929,7 +17115,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17951,7 +17136,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17973,7 +17157,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -17995,7 +17178,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18017,7 +17199,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18039,7 +17220,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18061,7 +17241,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18083,7 +17262,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18105,7 +17283,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18127,7 +17304,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18149,7 +17325,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18171,7 +17346,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18193,7 +17367,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18215,7 +17388,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18237,7 +17409,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18259,7 +17430,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18281,7 +17451,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18303,7 +17472,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18325,7 +17493,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18347,7 +17514,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18369,7 +17535,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18391,7 +17556,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18413,7 +17577,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18435,7 +17598,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18457,7 +17619,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18479,7 +17640,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18501,7 +17661,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18523,7 +17682,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18545,7 +17703,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18567,7 +17724,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18589,7 +17745,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18611,7 +17766,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18633,7 +17787,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18655,7 +17808,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18677,7 +17829,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18699,7 +17850,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18721,7 +17871,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18743,7 +17892,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18765,7 +17913,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18787,7 +17934,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18809,7 +17955,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18831,7 +17976,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18853,7 +17997,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18875,7 +18018,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18897,7 +18039,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18919,7 +18060,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18941,7 +18081,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18963,7 +18102,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -18985,7 +18123,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19007,7 +18144,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19029,7 +18165,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19051,7 +18186,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19073,7 +18207,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19095,7 +18228,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19117,7 +18249,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19139,7 +18270,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19161,7 +18291,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19183,7 +18312,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19205,7 +18333,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19227,7 +18354,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19249,7 +18375,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19271,7 +18396,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19293,7 +18417,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19315,7 +18438,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19337,7 +18459,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19359,7 +18480,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19381,7 +18501,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -19403,7 +18522,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kauniainen"
           }
         ],
         "coordinates": [
@@ -19425,7 +18543,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -19447,7 +18564,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19469,7 +18585,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19491,7 +18606,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19513,7 +18627,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19535,7 +18648,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19557,7 +18669,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19579,7 +18690,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19601,7 +18711,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19623,7 +18732,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19645,7 +18753,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19667,7 +18774,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19689,7 +18795,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19711,7 +18816,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -19733,7 +18837,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -19755,7 +18858,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19777,7 +18879,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19799,7 +18900,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19821,7 +18921,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19843,7 +18942,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19865,7 +18963,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -19887,7 +18984,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -19909,7 +19005,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -19931,7 +19026,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -19953,7 +19047,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -19975,7 +19068,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -19997,7 +19089,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -20019,7 +19110,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -20041,7 +19131,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -20063,7 +19152,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -20085,7 +19173,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20107,7 +19194,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20129,7 +19215,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20151,7 +19236,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20173,7 +19257,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20195,7 +19278,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20217,7 +19299,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20239,7 +19320,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20261,7 +19341,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20283,7 +19362,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20305,7 +19383,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20327,7 +19404,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20349,7 +19425,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20371,7 +19446,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20393,7 +19467,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20415,7 +19488,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20437,7 +19509,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20459,7 +19530,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20481,7 +19551,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20503,7 +19572,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20525,7 +19593,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20547,7 +19614,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20569,7 +19635,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20591,7 +19656,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20613,7 +19677,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20635,7 +19698,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20657,7 +19719,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20679,7 +19740,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20701,7 +19761,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20723,7 +19782,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20745,7 +19803,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20767,7 +19824,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20789,7 +19845,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20811,7 +19866,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20833,7 +19887,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20855,7 +19908,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20877,7 +19929,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -20899,7 +19950,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -20921,7 +19971,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -20943,7 +19992,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -20965,7 +20013,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -20987,7 +20034,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21009,7 +20055,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21031,7 +20076,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21053,7 +20097,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21075,7 +20118,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21097,7 +20139,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21119,7 +20160,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21141,7 +20181,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21163,7 +20202,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21185,7 +20223,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21207,7 +20244,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21229,7 +20265,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21251,7 +20286,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -21273,7 +20307,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21295,7 +20328,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21317,7 +20349,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21339,7 +20370,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21361,7 +20391,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21383,7 +20412,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21405,7 +20433,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21427,7 +20454,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21449,7 +20475,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21471,7 +20496,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21493,7 +20517,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kerava"
           }
         ],
         "coordinates": [
@@ -21515,7 +20538,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21537,7 +20559,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21559,7 +20580,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21581,7 +20601,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Sipoo"
           }
         ],
         "coordinates": [
@@ -21603,7 +20622,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21625,7 +20643,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Kirkkonummi"
           }
         ],
         "coordinates": [
@@ -21647,7 +20664,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21669,7 +20685,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21691,7 +20706,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
           }
         ],
         "coordinates": [
@@ -21713,7 +20727,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21735,7 +20748,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21757,7 +20769,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21779,7 +20790,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21801,7 +20811,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21823,7 +20832,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21845,7 +20853,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21867,7 +20874,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21889,7 +20895,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
@@ -21911,7 +20916,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21933,7 +20937,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21955,7 +20958,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21977,7 +20979,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Vantaa"
           }
         ],
         "coordinates": [
@@ -21999,7 +21000,6 @@
       "expected": {
         "properties": [
           {
-            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [

--- a/test_cases/zipTest.json
+++ b/test_cases/zipTest.json
@@ -20,7 +20,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammikuja 11",
             "postalcode": "07580"
           }
         ],
@@ -41,7 +40,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Palosuontie 205",
             "postalcode": "07530"
           }
         ],
@@ -62,7 +60,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiidenkirnujentie 302",
             "postalcode": "07530"
           }
         ],
@@ -83,7 +80,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Makkelintie 39",
             "postalcode": "07590"
           }
         ],
@@ -104,7 +100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myrskyläntie 506",
             "postalcode": "07590"
           }
         ],
@@ -125,7 +120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvasuontie 568b",
             "postalcode": "07590"
           }
         ],
@@ -146,7 +140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Oikotie 157",
             "postalcode": "07590"
           }
         ],
@@ -167,7 +160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kydöntie 71",
             "postalcode": "07510"
           }
         ],
@@ -188,7 +180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahijärvi",
             "postalcode": "07510"
           }
         ],
@@ -209,7 +200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suokujantie 90",
             "postalcode": "07510"
           }
         ],
@@ -230,7 +220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntytie 9",
             "postalcode": "07500"
           }
         ],
@@ -251,7 +240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Askolantie 57",
             "postalcode": "07510"
           }
         ],
@@ -272,7 +260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Niemenpellontie 10",
             "postalcode": "07510"
           }
         ],
@@ -293,7 +280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tamminiementie 79a",
             "postalcode": "07590"
           }
         ],
@@ -314,7 +300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myrskyläntie 804",
             "postalcode": "07590"
           }
         ],
@@ -335,7 +320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhuntie 75",
             "postalcode": "07590"
           }
         ],
@@ -356,7 +340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peltokuja 4",
             "postalcode": "07230"
           }
         ],
@@ -377,7 +360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Silakanojantie 306k",
             "postalcode": "07230"
           }
         ],
@@ -398,7 +380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pornaistentie 185",
             "postalcode": "07230"
           }
         ],
@@ -419,7 +400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rentukkakuja 36",
             "postalcode": "07590"
           }
         ],
@@ -440,7 +420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Juornaankyläntie 229b",
             "postalcode": "07680"
           }
         ],
@@ -461,7 +440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peräläntie 80",
             "postalcode": "07590"
           }
         ],
@@ -482,7 +460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntsäläntie 174",
             "postalcode": "07230"
           }
         ],
@@ -503,7 +480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Monsalankaari 9",
             "postalcode": "07230"
           }
         ],
@@ -524,7 +500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Uljaantie 4",
             "postalcode": "07230"
           }
         ],
@@ -545,7 +520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Silakanojantie",
             "postalcode": "07230"
           }
         ],
@@ -566,7 +540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustanlähteentie 39b",
             "postalcode": "07230"
           }
         ],
@@ -587,7 +560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pusantie 84a",
             "postalcode": "07680"
           }
         ],
@@ -608,7 +580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porvoontie 67b",
             "postalcode": "07230"
           }
         ],
@@ -629,7 +600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalliotie 1",
             "postalcode": "07230"
           }
         ],
@@ -650,7 +620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuoppatie 1",
             "postalcode": "07230"
           }
         ],
@@ -671,7 +640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuomitie 4",
             "postalcode": "07230"
           }
         ],
@@ -692,7 +660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntyrinteentie 7a",
             "postalcode": "07500"
           }
         ],
@@ -713,7 +680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suokujantie 285",
             "postalcode": "07510"
           }
         ],
@@ -734,7 +700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Emännänpiha 6",
             "postalcode": "02940"
           }
         ],
@@ -755,7 +720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallåker 11",
             "postalcode": "02740"
           }
         ],
@@ -776,7 +740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muurahaisenkuja 4",
             "postalcode": "02770"
           }
         ],
@@ -797,7 +760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sysimaa 7",
             "postalcode": "02740"
           }
         ],
@@ -818,7 +780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vesirattaanmäki 6",
             "postalcode": "02740"
           }
         ],
@@ -839,7 +800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aitovieri 2",
             "postalcode": "02940"
           }
         ],
@@ -860,7 +820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Läntinen teollisuuskatu 3",
             "postalcode": "02920"
           }
         ],
@@ -881,7 +840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Juvansyrjä 15",
             "postalcode": "02920"
           }
         ],
@@ -902,7 +860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purolaakso 9",
             "postalcode": "02920"
           }
         ],
@@ -923,7 +880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purometsä 9",
             "postalcode": "02920"
           }
         ],
@@ -944,7 +900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nikunkuja 6",
             "postalcode": "02920"
           }
         ],
@@ -965,7 +920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sipulipolku 2",
             "postalcode": "02920"
           }
         ],
@@ -986,7 +940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hevostilantie 4",
             "postalcode": "02920"
           }
         ],
@@ -1007,7 +960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nikunpellontanner 2",
             "postalcode": "02920"
           }
         ],
@@ -1028,7 +980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhuniityntie 22",
             "postalcode": "02810"
           }
         ],
@@ -1049,7 +1000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkasaari",
             "postalcode": "02160"
           }
         ],
@@ -1070,7 +1020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rautiaisentie 21",
             "postalcode": "02660"
           }
         ],
@@ -1091,7 +1040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiiralankaari 10",
             "postalcode": "02160"
           }
         ],
@@ -1112,7 +1060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tinapuisto 3",
             "postalcode": "02750"
           }
         ],
@@ -1133,7 +1080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nallenpolku 4",
             "postalcode": "02110"
           }
         ],
@@ -1154,7 +1100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aarnivalkeantie 10",
             "postalcode": "02100"
           }
         ],
@@ -1175,7 +1120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pronssitie 1a",
             "postalcode": "02750"
           }
         ],
@@ -1196,7 +1140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kromitie 13a",
             "postalcode": "02750"
           }
         ],
@@ -1217,7 +1160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lyijypolku 4",
             "postalcode": "02750"
           }
         ],
@@ -1238,7 +1180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lyijypolku 4",
             "postalcode": "02750"
           }
         ],
@@ -1259,7 +1200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakastiaisentie 3",
             "postalcode": "02660"
           }
         ],
@@ -1280,7 +1220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Länsitie 20",
             "postalcode": "02160"
           }
         ],
@@ -1301,7 +1240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Iltaruskontie 2",
             "postalcode": "02120"
           }
         ],
@@ -1322,7 +1260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Harjuviita 6",
             "postalcode": "02110"
           }
         ],
@@ -1343,7 +1280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kontionkuja 5",
             "postalcode": "02110"
           }
         ],
@@ -1364,7 +1300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuurinniityntie 16c",
             "postalcode": "02750"
           }
         ],
@@ -1385,7 +1320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Piilipuuntie 18",
             "postalcode": "02250"
           }
         ],
@@ -1406,7 +1340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suvikummunrinne 4",
             "postalcode": "02120"
           }
         ],
@@ -1427,7 +1360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Harjuviita 2",
             "postalcode": "02110"
           }
         ],
@@ -1448,7 +1380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tapiolanraitti",
             "postalcode": "02100"
           }
         ],
@@ -1469,7 +1400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kromitie 19",
             "postalcode": "02750"
           }
         ],
@@ -1490,7 +1420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänkaari 9",
             "postalcode": "02210"
           }
         ],
@@ -1511,7 +1440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pikkulinnunreitti 19",
             "postalcode": "02660"
           }
         ],
@@ -1532,7 +1460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hempontie 6b",
             "postalcode": "02660"
           }
         ],
@@ -1553,7 +1480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuurinmäentie 12",
             "postalcode": "02250"
           }
         ],
@@ -1574,7 +1500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tikaskallio 4",
             "postalcode": "02250"
           }
         ],
@@ -1595,7 +1520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuurinniityntie 8",
             "postalcode": "02250"
           }
         ],
@@ -1616,7 +1540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuutamokatu 6",
             "postalcode": "02210"
           }
         ],
@@ -1637,7 +1560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sulka 4",
             "postalcode": "02660"
           }
         ],
@@ -1658,7 +1580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuunkierros 3",
             "postalcode": "02210"
           }
         ],
@@ -1679,7 +1600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ellipsipolku 4",
             "postalcode": "02210"
           }
         ],
@@ -1700,7 +1620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pohjoinen Lintuvaarantie 30",
             "postalcode": "02600"
           }
         ],
@@ -1721,7 +1640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pajusirkuntie 5",
             "postalcode": "02660"
           }
         ],
@@ -1742,7 +1660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suvelantie 16",
             "postalcode": "02760"
           }
         ],
@@ -1763,7 +1680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pulmusentie 1",
             "postalcode": "02660"
           }
         ],
@@ -1784,7 +1700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Upseerinkatu 1",
             "postalcode": "02600"
           }
         ],
@@ -1805,7 +1720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vallikallionkuja 2",
             "postalcode": "02650"
           }
         ],
@@ -1826,7 +1740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porarinkatu 7",
             "postalcode": "02650"
           }
         ],
@@ -1847,7 +1760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lahnuksentie 31",
             "postalcode": "02970"
           }
         ],
@@ -1868,7 +1780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jalavakuja 1",
             "postalcode": "02760"
           }
         ],
@@ -1889,7 +1800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sunantie 19",
             "postalcode": "02760"
           }
         ],
@@ -1910,7 +1820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ajurinkatu 4",
             "postalcode": "02650"
           }
         ],
@@ -1931,7 +1840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Yläkalliontie 3",
             "postalcode": "02760"
           }
         ],
@@ -1952,7 +1860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Yläniityntie 3",
             "postalcode": "02760"
           }
         ],
@@ -1973,7 +1880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Postipuuntie 10",
             "postalcode": "02650"
           }
         ],
@@ -1994,7 +1900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vermonkuja 6",
             "postalcode": "00370"
           }
         ],
@@ -2015,7 +1920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vermonpolku 3",
             "postalcode": "00370"
           }
         ],
@@ -2036,7 +1940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lahnuksentie 19-21",
             "postalcode": "02970"
           }
         ],
@@ -2057,7 +1960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Huhtamäentie 12",
             "postalcode": "02970"
           }
         ],
@@ -2078,7 +1980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sunankalliontie 33",
             "postalcode": "02760"
           }
         ],
@@ -2099,7 +2000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Eriksbergintie 4",
             "postalcode": "02970"
           }
         ],
@@ -2120,7 +2020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammilaaksontie 3b",
             "postalcode": "02330"
           }
         ],
@@ -2141,7 +2040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Alakalliontie 2",
             "postalcode": "02760"
           }
         ],
@@ -2162,7 +2060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veräjäpellonkatu 17",
             "postalcode": "02650"
           }
         ],
@@ -2183,7 +2080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkkylänmutka 5",
             "postalcode": "02650"
           }
         ],
@@ -2204,7 +2100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukkaromäki 2",
             "postalcode": "02770"
           }
         ],
@@ -2225,7 +2120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Liittokuja 2",
             "postalcode": "02770"
           }
         ],
@@ -2246,7 +2140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahtirinne 6",
             "postalcode": "00370"
           }
         ],
@@ -2267,7 +2160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sokerilinnantie 2",
             "postalcode": "02600"
           }
         ],
@@ -2288,7 +2180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiiltokalliontie 8",
             "postalcode": "02180"
           }
         ],
@@ -2309,7 +2200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaksoiskiventie 45",
             "postalcode": "02760"
           }
         ],
@@ -2330,7 +2220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiiltokalliontie 13",
             "postalcode": "02180"
           }
         ],
@@ -2351,7 +2240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaksoiskiventie 7-9",
             "postalcode": "02760"
           }
         ],
@@ -2372,7 +2260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sepelkyyhkyntie 1",
             "postalcode": "02660"
           }
         ],
@@ -2393,7 +2280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Luhtatie 22",
             "postalcode": "02760"
           }
         ],
@@ -2414,7 +2300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkännotkontie 7",
             "postalcode": "02760"
           }
         ],
@@ -2435,7 +2320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotaviskaalintie 1",
             "postalcode": "00370"
           }
         ],
@@ -2456,7 +2340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalliorinne 5",
             "postalcode": "02770"
           }
         ],
@@ -2477,7 +2360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Talkoorinne 6",
             "postalcode": "02760"
           }
         ],
@@ -2498,7 +2380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heinäväenkuja 5",
             "postalcode": "02760"
           }
         ],
@@ -2519,7 +2400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Talkookuja 5",
             "postalcode": "02760"
           }
         ],
@@ -2540,7 +2420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Puistotie 12a",
             "postalcode": "02760"
           }
         ],
@@ -2561,7 +2440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaksoiskiventie 49",
             "postalcode": "02760"
           }
         ],
@@ -2582,7 +2460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuotiotie 17",
             "postalcode": "02600"
           }
         ],
@@ -2603,7 +2480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ratavallintie 5",
             "postalcode": "02760"
           }
         ],
@@ -2624,7 +2500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyyhkysmäki 18",
             "postalcode": "02650"
           }
         ],
@@ -2645,7 +2520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rannikontie 8",
             "postalcode": "02780"
           }
         ],
@@ -2666,7 +2540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rannikontie 11",
             "postalcode": "02780"
           }
         ],
@@ -2687,7 +2560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keskitie 7",
             "postalcode": "02330"
           }
         ],
@@ -2708,7 +2580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoriharjuntie 47",
             "postalcode": "02330"
           }
         ],
@@ -2729,7 +2600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiltaraitti 3",
             "postalcode": "02770"
           }
         ],
@@ -2750,7 +2620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hösmärintie 3",
             "postalcode": "02770"
           }
         ],
@@ -2771,7 +2640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Löylytie 6",
             "postalcode": "02770"
           }
         ],
@@ -2792,7 +2660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nikunmäki 16",
             "postalcode": "02920"
           }
         ],
@@ -2813,7 +2680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Minttupelto 11",
             "postalcode": "02920"
           }
         ],
@@ -2834,7 +2700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsäkukantie 2",
             "postalcode": "02330"
           }
         ],
@@ -2855,7 +2720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsäkukantie 4",
             "postalcode": "02330"
           }
         ],
@@ -2876,7 +2740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiuaskuja 3b",
             "postalcode": "02770"
           }
         ],
@@ -2897,7 +2760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoripirtintie 2",
             "postalcode": "02330"
           }
         ],
@@ -2918,7 +2780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Saunamäentie 31",
             "postalcode": "02770"
           }
         ],
@@ -2939,7 +2800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Penkkikuja 4",
             "postalcode": "02770"
           }
         ],
@@ -2960,7 +2820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Penkkikuja 6",
             "postalcode": "02770"
           }
         ],
@@ -2981,7 +2840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäentie 23b",
             "postalcode": "02920"
           }
         ],
@@ -3002,7 +2860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivipylvääntie 16a",
             "postalcode": "02940"
           }
         ],
@@ -3023,7 +2880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Staffanintie 17",
             "postalcode": "02360"
           }
         ],
@@ -3044,7 +2900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukanniemi 10",
             "postalcode": "02360"
           }
         ],
@@ -3065,7 +2920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peringintie 1a",
             "postalcode": "02780"
           }
         ],
@@ -3086,7 +2940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Savitiilenkuja 2",
             "postalcode": "02330"
           }
         ],
@@ -3107,7 +2960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rakentajaintie 24c",
             "postalcode": "02330"
           }
         ],
@@ -3128,7 +2980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kihokkiniitty 13",
             "postalcode": "02970"
           }
         ],
@@ -3149,7 +3000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laidunkuja 2",
             "postalcode": "02330"
           }
         ],
@@ -3170,7 +3020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rakentajainkuja 12",
             "postalcode": "02330"
           }
         ],
@@ -3191,7 +3040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porrastie 5",
             "postalcode": "02330"
           }
         ],
@@ -3212,7 +3060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Staffanintie 10",
             "postalcode": "02360"
           }
         ],
@@ -3233,7 +3080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Svartholmen Soukka",
             "postalcode": "02360"
           }
         ],
@@ -3254,7 +3100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Latvatie 18",
             "postalcode": "02710"
           }
         ],
@@ -3275,7 +3120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tähdenlennontie 5",
             "postalcode": "02240"
           }
         ],
@@ -3296,7 +3140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Friisinniityntie 2",
             "postalcode": "02240"
           }
         ],
@@ -3317,7 +3160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Friisinniityntie 17",
             "postalcode": "02240"
           }
         ],
@@ -3338,7 +3180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tähdenlennontie 57",
             "postalcode": "02240"
           }
         ],
@@ -3359,7 +3200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Friisiläntie 30",
             "postalcode": "02240"
           }
         ],
@@ -3380,7 +3220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tapiontie 8a",
             "postalcode": "02720"
           }
         ],
@@ -3401,7 +3240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirsitie 12",
             "postalcode": "02720"
           }
         ],
@@ -3422,7 +3260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirsitie 31",
             "postalcode": "02720"
           }
         ],
@@ -3443,7 +3280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hirsitie 35",
             "postalcode": "02720"
           }
         ],
@@ -3464,7 +3300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Isonmäenkuja 4",
             "postalcode": "02970"
           }
         ],
@@ -3485,7 +3320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Etelätie 24",
             "postalcode": "02710"
           }
         ],
@@ -3506,7 +3340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karpintie 16",
             "postalcode": "02260"
           }
         ],
@@ -3527,7 +3360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sammenpolku 3",
             "postalcode": "02260"
           }
         ],
@@ -3548,7 +3380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mariannantie 22",
             "postalcode": "02970"
           }
         ],
@@ -3569,7 +3400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mariannantie 24",
             "postalcode": "02970"
           }
         ],
@@ -3590,7 +3420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jupperintie 2",
             "postalcode": "02730"
           }
         ],
@@ -3611,7 +3440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jupperinmetsä 10",
             "postalcode": "02730"
           }
         ],
@@ -3632,7 +3460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuudes järvikuja 3",
             "postalcode": "02730"
           }
         ],
@@ -3653,7 +3480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehtitie 30",
             "postalcode": "02730"
           }
         ],
@@ -3674,7 +3500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksolahdentie 90",
             "postalcode": "02730"
           }
         ],
@@ -3695,7 +3520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rinnetie 9",
             "postalcode": "02730"
           }
         ],
@@ -3716,7 +3540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahverokuja 6",
             "postalcode": "02730"
           }
         ],
@@ -3737,7 +3560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korpilaakso 8",
             "postalcode": "02970"
           }
         ],
@@ -3758,7 +3580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsämaantie 19a",
             "postalcode": "02970"
           }
         ],
@@ -3779,7 +3600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Örkkiniityntie 54",
             "postalcode": "02970"
           }
         ],
@@ -3800,7 +3620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammipääntie 9",
             "postalcode": "02730"
           }
         ],
@@ -3821,7 +3640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Palomäentie 12",
             "postalcode": "02730"
           }
         ],
@@ -3842,7 +3660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vahverotie 8",
             "postalcode": "02730"
           }
         ],
@@ -3863,7 +3680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Stenbackantie 8",
             "postalcode": "02780"
           }
         ],
@@ -3884,7 +3700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mulbyntie 7",
             "postalcode": "02780"
           }
         ],
@@ -3905,7 +3720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkituvantie 4",
             "postalcode": "02780"
           }
         ],
@@ -3926,7 +3740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Saunaniementie 11",
             "postalcode": "02780"
           }
         ],
@@ -3947,7 +3760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Parsitie 5",
             "postalcode": "02620"
           }
         ],
@@ -3968,7 +3780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riihiuunintie 2a",
             "postalcode": "02620"
           }
         ],
@@ -3989,7 +3800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Äraportti 3",
             "postalcode": "02620"
           }
         ],
@@ -4010,7 +3820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keskitie 16",
             "postalcode": "02330"
           }
         ],
@@ -4031,7 +3840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Rastaalantie 29",
             "postalcode": "02620"
           }
         ],
@@ -4052,7 +3860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veininmäki 10",
             "postalcode": "02620"
           }
         ],
@@ -4073,7 +3880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rastaalanrinne 6",
             "postalcode": "02620"
           }
         ],
@@ -4094,7 +3900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Martinmetsä 2",
             "postalcode": "02300"
           }
         ],
@@ -4115,7 +3920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Olkiniitty 4",
             "postalcode": "02620"
           }
         ],
@@ -4136,7 +3940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Törmäniityntie 5",
             "postalcode": "02710"
           }
         ],
@@ -4157,7 +3960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Törmänsilmänkuja 12",
             "postalcode": "02710"
           }
         ],
@@ -4178,7 +3980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lukionahde 1",
             "postalcode": "02710"
           }
         ],
@@ -4199,7 +4000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuuniitynkuja 2",
             "postalcode": "02710"
           }
         ],
@@ -4220,7 +4020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suokalliontie 22c",
             "postalcode": "02860"
           }
         ],
@@ -4241,7 +4040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Herastuomarintie 9",
             "postalcode": "02770"
           }
         ],
@@ -4262,7 +4060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tikasniitynkuja 14",
             "postalcode": "02250"
           }
         ],
@@ -4283,7 +4080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Svartholmantie 3",
             "postalcode": "02380"
           }
         ],
@@ -4304,7 +4100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Örkkiniitynkuja 8",
             "postalcode": "02970"
           }
         ],
@@ -4325,7 +4120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korpilammentie 10e",
             "postalcode": "02970"
           }
         ],
@@ -4346,7 +4140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viiripelto 5",
             "postalcode": "02970"
           }
         ],
@@ -4367,7 +4160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Storgårdintie 3",
             "postalcode": "02970"
           }
         ],
@@ -4388,7 +4180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aapontie 12",
             "postalcode": "02180"
           }
         ],
@@ -4409,7 +4200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvalammentie 14",
             "postalcode": "02740"
           }
         ],
@@ -4430,7 +4220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvarinne 3",
             "postalcode": "02740"
           }
         ],
@@ -4451,7 +4240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keltonkuja 4",
             "postalcode": "02180"
           }
         ],
@@ -4472,7 +4260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvalammentie 12",
             "postalcode": "02740"
           }
         ],
@@ -4493,7 +4280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sorvalammenkuja 2",
             "postalcode": "02740"
           }
         ],
@@ -4514,7 +4300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähäntorpankuja 7",
             "postalcode": "02180"
           }
         ],
@@ -4535,7 +4320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkaniityntie 3",
             "postalcode": "02180"
           }
         ],
@@ -4556,7 +4340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkarinne 4a",
             "postalcode": "02180"
           }
         ],
@@ -4577,7 +4360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tollinrinne 10",
             "postalcode": "02740"
           }
         ],
@@ -4598,7 +4380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkamäentie 1b",
             "postalcode": "02180"
           }
         ],
@@ -4619,7 +4400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kruununkuja 4",
             "postalcode": "02180"
           }
         ],
@@ -4640,7 +4420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Bellinrinne 4",
             "postalcode": "02740"
           }
         ],
@@ -4661,7 +4440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kunnarlantie 52",
             "postalcode": "02740"
           }
         ],
@@ -4682,7 +4460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lukkarinojantie 14",
             "postalcode": "02740"
           }
         ],
@@ -4703,7 +4480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Piispanpiha 5",
             "postalcode": "02200"
           }
         ],
@@ -4724,7 +4500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porttitie 25",
             "postalcode": "02180"
           }
         ],
@@ -4745,7 +4520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porttiniityntie 8",
             "postalcode": "02180"
           }
         ],
@@ -4766,7 +4540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Puuhkalakintie 26",
             "postalcode": "02780"
           }
         ],
@@ -4787,7 +4560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kavallinmäki 7",
             "postalcode": "02710"
           }
         ],
@@ -4808,7 +4580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalmarintie 5a",
             "postalcode": "02740"
           }
         ],
@@ -4829,7 +4600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kunnarlantie 94",
             "postalcode": "02740"
           }
         ],
@@ -4850,7 +4620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Bodominkuja 4",
             "postalcode": "02940"
           }
         ],
@@ -4871,7 +4640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiidenkiukaantie 5",
             "postalcode": "02280"
           }
         ],
@@ -4892,7 +4660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Liljapolku 6",
             "postalcode": "02210"
           }
         ],
@@ -4913,7 +4680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Syreenipolku 8",
             "postalcode": "02210"
           }
         ],
@@ -4934,7 +4700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tervaspiha 6",
             "postalcode": "02210"
           }
         ],
@@ -4955,7 +4720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sakkolantie 16",
             "postalcode": "02140"
           }
         ],
@@ -4976,7 +4740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Turuntie 150",
             "postalcode": "02740"
           }
         ],
@@ -4997,7 +4760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuninkaankartanontie 10",
             "postalcode": "02780"
           }
         ],
@@ -5018,7 +4780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Luuvanmetsä 6",
             "postalcode": "02620"
           }
         ],
@@ -5039,7 +4800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalajärvenranta 11",
             "postalcode": "02970"
           }
         ],
@@ -5060,7 +4820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Röyläntie 38",
             "postalcode": "02940"
           }
         ],
@@ -5081,7 +4840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lahnuksentie 49",
             "postalcode": "02970"
           }
         ],
@@ -5102,7 +4860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tippavaara",
             "postalcode": "02970"
           }
         ],
@@ -5123,7 +4880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Nemlahdentie 3",
             "postalcode": "02970"
           }
         ],
@@ -5144,7 +4900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoriharjuntie 51",
             "postalcode": "02330"
           }
         ],
@@ -5165,7 +4920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsätorpantie 8b",
             "postalcode": "02940"
           }
         ],
@@ -5186,7 +4940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lakeanmäentie 1",
             "postalcode": "02750"
           }
         ],
@@ -5207,7 +4960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vasaramäki 8",
             "postalcode": "02750"
           }
         ],
@@ -5228,7 +4980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Luukintie 4",
             "postalcode": "02940"
           }
         ],
@@ -5249,7 +5000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ramsiontie 7",
             "postalcode": "02380"
           }
         ],
@@ -5270,7 +5020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kopplakobben",
             "postalcode": "02380"
           }
         ],
@@ -5291,7 +5040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoriharjuntie 16",
             "postalcode": "02330"
           }
         ],
@@ -5312,7 +5060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hyljelahdentie 19",
             "postalcode": "02260"
           }
         ],
@@ -5333,7 +5080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hyljeveneentie 1",
             "postalcode": "02260"
           }
         ],
@@ -5354,7 +5100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kavallinkuja 1",
             "postalcode": "02710"
           }
         ],
@@ -5375,7 +5120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Helsingintie 57",
             "postalcode": "02710"
           }
         ],
@@ -5396,7 +5140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Järvitorppa 6",
             "postalcode": "02360"
           }
         ],
@@ -5417,7 +5160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ylärinne 13",
             "postalcode": "02360"
           }
         ],
@@ -5438,7 +5180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Åminnenranta 4",
             "postalcode": "02780"
           }
         ],
@@ -5459,7 +5200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkirinne 5",
             "postalcode": "02360"
           }
         ],
@@ -5480,7 +5220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaitaankulma 6",
             "postalcode": "02360"
           }
         ],
@@ -5501,7 +5240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaitaanportti 4",
             "postalcode": "02360"
           }
         ],
@@ -5522,7 +5260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heiniemenpolku 8b",
             "postalcode": "02940"
           }
         ],
@@ -5543,7 +5280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vilniementie 1",
             "postalcode": "02940"
           }
         ],
@@ -5564,7 +5300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hannusjärventie 3",
             "postalcode": "02360"
           }
         ],
@@ -5585,7 +5320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hannusjärventie 3",
             "postalcode": "02360"
           }
         ],
@@ -5606,7 +5340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hannusranta 8",
             "postalcode": "02260"
           }
         ],
@@ -5627,7 +5360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viputie 14-16",
             "postalcode": "02940"
           }
         ],
@@ -5648,7 +5380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kielotie 4",
             "postalcode": "02260"
           }
         ],
@@ -5669,7 +5400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hannuksenrinne 1",
             "postalcode": "02270"
           }
         ],
@@ -5690,7 +5420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kahakuja 6",
             "postalcode": "02940"
           }
         ],
@@ -5711,7 +5440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolkerannantie 8",
             "postalcode": "02940"
           }
         ],
@@ -5732,7 +5460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnustajantie 6",
             "postalcode": "02940"
           }
         ],
@@ -5753,7 +5480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnustajantie 11",
             "postalcode": "02940"
           }
         ],
@@ -5774,7 +5500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vesiniityntie 6",
             "postalcode": "02360"
           }
         ],
@@ -5795,7 +5520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rysäkuja 10",
             "postalcode": "02260"
           }
         ],
@@ -5816,7 +5540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lippajärventie 44",
             "postalcode": "02940"
           }
         ],
@@ -5837,7 +5560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ajokoirantie 9b",
             "postalcode": "02940"
           }
         ],
@@ -5858,7 +5580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäjärvenranta 29",
             "postalcode": "02730"
           }
         ],
@@ -5879,7 +5600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nummitie 25",
             "postalcode": "02730"
           }
         ],
@@ -5900,7 +5620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukankaari 13",
             "postalcode": "02360"
           }
         ],
@@ -5921,7 +5640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukan rantatie 6",
             "postalcode": "02360"
           }
         ],
@@ -5942,7 +5660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukan rantatie 8",
             "postalcode": "02360"
           }
         ],
@@ -5963,7 +5680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauklahdentie 1",
             "postalcode": "02780"
           }
         ],
@@ -5984,7 +5700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauklahdentie 1",
             "postalcode": "02780"
           }
         ],
@@ -6005,7 +5720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukan rantatie 14",
             "postalcode": "02360"
           }
         ],
@@ -6026,7 +5740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukanlahdentie 5",
             "postalcode": "02360"
           }
         ],
@@ -6047,7 +5760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riihikuja 11",
             "postalcode": "02620"
           }
         ],
@@ -6068,7 +5780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purometsä 14",
             "postalcode": "02920"
           }
         ],
@@ -6089,7 +5800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäentie 12a",
             "postalcode": "02920"
           }
         ],
@@ -6110,7 +5820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nikunpellontörmä 6",
             "postalcode": "02920"
           }
         ],
@@ -6131,7 +5840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukansalmentie 14d",
             "postalcode": "02360"
           }
         ],
@@ -6152,7 +5860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Salmensuu 2",
             "postalcode": "02360"
           }
         ],
@@ -6173,7 +5880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Odilammentie 21",
             "postalcode": "02970"
           }
         ],
@@ -6194,7 +5900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Odilammentie 13",
             "postalcode": "02970"
           }
         ],
@@ -6215,7 +5920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soukansalmenkuja 3d",
             "postalcode": "02360"
           }
         ],
@@ -6236,7 +5940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Salmenpolku 4",
             "postalcode": "02360"
           }
         ],
@@ -6257,7 +5960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ampujanmäki 5",
             "postalcode": "02360"
           }
         ],
@@ -6278,7 +5980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuorisontie 8",
             "postalcode": "02920"
           }
         ],
@@ -6299,7 +6000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Merivalkama 7",
             "postalcode": "02320"
           }
         ],
@@ -6320,7 +6020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ståhlentie 13",
             "postalcode": "02920"
           }
         ],
@@ -6341,7 +6040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tyrskykuja 2",
             "postalcode": "02320"
           }
         ],
@@ -6362,7 +6060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aallonkohina 2",
             "postalcode": "02320"
           }
         ],
@@ -6383,7 +6080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Näkinkaari 2",
             "postalcode": "02320"
           }
         ],
@@ -6404,7 +6100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Valssitie 13",
             "postalcode": "02920"
           }
         ],
@@ -6425,7 +6120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Valssitie 16",
             "postalcode": "02920"
           }
         ],
@@ -6446,7 +6140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurinlahdentie 21",
             "postalcode": "02320"
           }
         ],
@@ -6467,7 +6160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Näkki 3",
             "postalcode": "02320"
           }
         ],
@@ -6488,7 +6180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Krattikuja 4",
             "postalcode": "02320"
           }
         ],
@@ -6509,7 +6200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurinlahdenkuja 4",
             "postalcode": "02320"
           }
         ],
@@ -6530,7 +6220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurinlahdenkuja 16",
             "postalcode": "02320"
           }
         ],
@@ -6551,7 +6240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viiskorvenmäki 5",
             "postalcode": "02920"
           }
         ],
@@ -6572,7 +6260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suonlaita 3",
             "postalcode": "02970"
           }
         ],
@@ -6593,7 +6280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäen puistotie 25",
             "postalcode": "02920"
           }
         ],
@@ -6614,7 +6300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laurinlahdenkuja 7",
             "postalcode": "02320"
           }
         ],
@@ -6635,7 +6320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ristiniementie 26",
             "postalcode": "02320"
           }
         ],
@@ -6656,7 +6340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ahotie 11",
             "postalcode": "02940"
           }
         ],
@@ -6677,7 +6360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ohrakuja 4",
             "postalcode": "02920"
           }
         ],
@@ -6698,7 +6380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viiskorvenmäki 8",
             "postalcode": "02920"
           }
         ],
@@ -6719,7 +6400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viiskorvenmäki 8",
             "postalcode": "02920"
           }
         ],
@@ -6740,7 +6420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ristiniementie 32",
             "postalcode": "02320"
           }
         ],
@@ -6761,7 +6440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ristiniementie 36",
             "postalcode": "02320"
           }
         ],
@@ -6782,7 +6460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Manninpellontie 25",
             "postalcode": "02970"
           }
         ],
@@ -6803,7 +6480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kortesrinne 8",
             "postalcode": "02970"
           }
         ],
@@ -6824,7 +6500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhankartanontie 32",
             "postalcode": "02920"
           }
         ],
@@ -6845,7 +6520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruorikuja 4",
             "postalcode": "02320"
           }
         ],
@@ -6866,7 +6540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karantie 2",
             "postalcode": "02630"
           }
         ],
@@ -6887,7 +6560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nihtisalontie 17",
             "postalcode": "02630"
           }
         ],
@@ -6908,7 +6580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nihtikuja 5",
             "postalcode": "02630"
           }
         ],
@@ -6929,7 +6600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vitikka 1",
             "postalcode": "02630"
           }
         ],
@@ -6950,7 +6620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kelkkamäki 12",
             "postalcode": "02610"
           }
         ],
@@ -6971,7 +6640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilontie 16",
             "postalcode": "02610"
           }
         ],
@@ -6992,7 +6660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilontie 16",
             "postalcode": "02610"
           }
         ],
@@ -7013,7 +6680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiviharjuntie 2",
             "postalcode": "02330"
           }
         ],
@@ -7034,7 +6700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Herttuantie 1",
             "postalcode": "02610"
           }
         ],
@@ -7055,7 +6720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuninkaistentie 7",
             "postalcode": "02610"
           }
         ],
@@ -7076,7 +6740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilontie 8",
             "postalcode": "02610"
           }
         ],
@@ -7097,7 +6760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lansanportti 6b",
             "postalcode": "02630"
           }
         ],
@@ -7118,7 +6780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruotutorppa 6",
             "postalcode": "02610"
           }
         ],
@@ -7139,7 +6800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilpitie 15",
             "postalcode": "02610"
           }
         ],
@@ -7160,7 +6820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilpitie 11",
             "postalcode": "02610"
           }
         ],
@@ -7181,7 +6840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kypäräkuja 3",
             "postalcode": "02610"
           }
         ],
@@ -7202,7 +6860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linkomäki 2",
             "postalcode": "02630"
           }
         ],
@@ -7223,7 +6880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Siuntionkuja 7",
             "postalcode": "02600"
           }
         ],
@@ -7244,7 +6900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Degerbyntie 21",
             "postalcode": "02600"
           }
         ],
@@ -7265,7 +6920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Degerbyntie 23",
             "postalcode": "02600"
           }
         ],
@@ -7286,7 +6940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Stensinmäki 4",
             "postalcode": "02750"
           }
         ],
@@ -7307,7 +6960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hakarinne 6",
             "postalcode": "02120"
           }
         ],
@@ -7328,7 +6980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sateenkuja 7",
             "postalcode": "02100"
           }
         ],
@@ -7349,7 +7000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peuramäentie 2",
             "postalcode": "02750"
           }
         ],
@@ -7370,7 +7020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuoripirtintie 11",
             "postalcode": "02330"
           }
         ],
@@ -7391,7 +7040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalevanvainio 8",
             "postalcode": "02100"
           }
         ],
@@ -7412,7 +7060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihkapolku 1",
             "postalcode": "02110"
           }
         ],
@@ -7433,7 +7080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ymmerstanmäki 16",
             "postalcode": "02750"
           }
         ],
@@ -7454,7 +7100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ristihaantie 9",
             "postalcode": "02750"
           }
         ],
@@ -7475,7 +7120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaupinkalliontie 4",
             "postalcode": "02100"
           }
         ],
@@ -7496,7 +7140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivuhovintie 8",
             "postalcode": "02750"
           }
         ],
@@ -7517,7 +7160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauppalanportti 1",
             "postalcode": "02750"
           }
         ],
@@ -7538,7 +7180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotkatie 6",
             "postalcode": "02620"
           }
         ],
@@ -7559,7 +7200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lyökkiniemi 20",
             "postalcode": "02160"
           }
         ],
@@ -7580,7 +7220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiiralantie 1",
             "postalcode": "02160"
           }
         ],
@@ -7601,7 +7240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiiralankaari 13",
             "postalcode": "02160"
           }
         ],
@@ -7622,7 +7260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Varpushaukankuja 8",
             "postalcode": "02620"
           }
         ],
@@ -7643,7 +7280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pääskyskuja 8",
             "postalcode": "02620"
           }
         ],
@@ -7664,7 +7300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäensyrjä 2",
             "postalcode": "02160"
           }
         ],
@@ -7685,7 +7320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hallavantorpantie 5",
             "postalcode": "02820"
           }
         ],
@@ -7706,7 +7340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Westendintie 93",
             "postalcode": "02160"
           }
         ],
@@ -7727,7 +7360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Munkkiluodonkuja 2",
             "postalcode": "02160"
           }
         ],
@@ -7748,7 +7380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Telakuja 1",
             "postalcode": "02170"
           }
         ],
@@ -7769,7 +7400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurkihirrentie 8",
             "postalcode": "02330"
           }
         ],
@@ -7790,7 +7420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keltarousku 5",
             "postalcode": "02730"
           }
         ],
@@ -7811,7 +7440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Itäviitta 3",
             "postalcode": "02330"
           }
         ],
@@ -7832,7 +7460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paasikuja 6b",
             "postalcode": "02330"
           }
         ],
@@ -7853,7 +7480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Länsimetsä 9",
             "postalcode": "02300"
           }
         ],
@@ -7874,7 +7500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Välimetsä 9",
             "postalcode": "02300"
           }
         ],
@@ -7895,7 +7520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmas huvilatie 10",
             "postalcode": "02730"
           }
         ],
@@ -7916,7 +7540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Martinmetsä 17",
             "postalcode": "02300"
           }
         ],
@@ -7937,7 +7560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuudes huvilatie 5",
             "postalcode": "02730"
           }
         ],
@@ -7958,7 +7580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksolahdentie 92",
             "postalcode": "02730"
           }
         ],
@@ -7979,7 +7600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Brändholm",
             "postalcode": "02230"
           }
         ],
@@ -8000,7 +7620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ylänkörinne 7",
             "postalcode": "02730"
           }
         ],
@@ -8021,7 +7640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäjärventie 31b",
             "postalcode": "02730"
           }
         ],
@@ -8042,7 +7660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänkajontie 9",
             "postalcode": "02210"
           }
         ],
@@ -8063,7 +7680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Iivisniemenkatu 4",
             "postalcode": "02260"
           }
         ],
@@ -8084,7 +7700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ensimmäinen huvilatie 5b",
             "postalcode": "02730"
           }
         ],
@@ -8105,7 +7720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksolahdentie 30a",
             "postalcode": "02720"
           }
         ],
@@ -8126,7 +7740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Etelätie 33",
             "postalcode": "02710"
           }
         ],
@@ -8147,7 +7760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavinharju 8",
             "postalcode": "02180"
           }
         ],
@@ -8168,7 +7780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurutie 22",
             "postalcode": "02810"
           }
         ],
@@ -8189,7 +7800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmperänkuja 4",
             "postalcode": "02820"
           }
         ],
@@ -8210,7 +7820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmperänkuja 9",
             "postalcode": "02820"
           }
         ],
@@ -8231,7 +7840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhusuonkuja 15",
             "postalcode": "02810"
           }
         ],
@@ -8252,7 +7860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rintinrinne 6",
             "postalcode": "02820"
           }
         ],
@@ -8273,7 +7880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustanpurontie 23",
             "postalcode": "02820"
           }
         ],
@@ -8294,7 +7900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Brobackantie 29",
             "postalcode": "02820"
           }
         ],
@@ -8315,7 +7920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Haukkalammentie 9",
             "postalcode": "02820"
           }
         ],
@@ -8336,7 +7940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pertuskatie 11",
             "postalcode": "02630"
           }
         ],
@@ -8357,7 +7960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Toivalankuja 4",
             "postalcode": "02820"
           }
         ],
@@ -8378,7 +7980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurintie 33",
             "postalcode": "02820"
           }
         ],
@@ -8399,7 +8000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuuksiontie 44",
             "postalcode": "02820"
           }
         ],
@@ -8420,7 +8020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suopursunkuja 11",
             "postalcode": "02860"
           }
         ],
@@ -8441,7 +8040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hansatie 24",
             "postalcode": "02780"
           }
         ],
@@ -8462,7 +8060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauristie 22",
             "postalcode": "02860"
           }
         ],
@@ -8483,7 +8080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauristie 12",
             "postalcode": "02860"
           }
         ],
@@ -8504,7 +8100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kauristie 5",
             "postalcode": "02860"
           }
         ],
@@ -8525,7 +8120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Siikajärvenranta 30",
             "postalcode": "02860"
           }
         ],
@@ -8546,7 +8140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kolmirannantie 25",
             "postalcode": "02820"
           }
         ],
@@ -8567,7 +8160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuohikallio 8",
             "postalcode": "02860"
           }
         ],
@@ -8588,7 +8180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fickenkuja 4",
             "postalcode": "02780"
           }
         ],
@@ -8609,7 +8200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perusmäentie 11",
             "postalcode": "02920"
           }
         ],
@@ -8630,7 +8220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotimäenrinne 6",
             "postalcode": "02860"
           }
         ],
@@ -8651,7 +8240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heinäslammentie 13",
             "postalcode": "02860"
           }
         ],
@@ -8672,7 +8260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuohikallio 11",
             "postalcode": "02860"
           }
         ],
@@ -8693,7 +8280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotimäentie 17",
             "postalcode": "02860"
           }
         ],
@@ -8714,7 +8300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustanpurontie 11b",
             "postalcode": "02820"
           }
         ],
@@ -8735,7 +8320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Maulantie 12",
             "postalcode": "02820"
           }
         ],
@@ -8756,7 +8340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ykköstie 18",
             "postalcode": "02820"
           }
         ],
@@ -8777,7 +8360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veikkaustie 32",
             "postalcode": "02820"
           }
         ],
@@ -8798,7 +8380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurinrinne 9",
             "postalcode": "02820"
           }
         ],
@@ -8819,7 +8400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kakkostie 12b",
             "postalcode": "02820"
           }
         ],
@@ -8840,7 +8420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pieni Lehtisaari",
             "postalcode": "02380"
           }
         ],
@@ -8861,7 +8440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallåkerinrinne 2",
             "postalcode": "02740"
           }
         ],
@@ -8882,7 +8460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kilpitie 13",
             "postalcode": "02610"
           }
         ],
@@ -8903,7 +8480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Iso Lehtisaari",
             "postalcode": "02380"
           }
         ],
@@ -8924,7 +8500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veistokuja 2a",
             "postalcode": "02330"
           }
         ],
@@ -8945,7 +8520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lähderannantie 18",
             "postalcode": "02720"
           }
         ],
@@ -8966,7 +8540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Asgård 3",
             "postalcode": "02780"
           }
         ],
@@ -8987,7 +8560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Forsbackantie 18-20",
             "postalcode": "02780"
           }
         ],
@@ -9008,7 +8580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perustajantie 1",
             "postalcode": "02920"
           }
         ],
@@ -9029,7 +8600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peltoportti 3",
             "postalcode": "02920"
           }
         ],
@@ -9050,7 +8620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuninkaansatama 4",
             "postalcode": "02160"
           }
         ],
@@ -9071,7 +8640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuottaniementie 3",
             "postalcode": "02230"
           }
         ],
@@ -9092,7 +8660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lohitie 3",
             "postalcode": "02170"
           }
         ],
@@ -9113,7 +8680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaskilaaksontie 1",
             "postalcode": "02360"
           }
         ],
@@ -9134,7 +8700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Madetie 10",
             "postalcode": "02170"
           }
         ],
@@ -9155,7 +8720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Särkitie 7",
             "postalcode": "02170"
           }
         ],
@@ -9176,7 +8740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuhkurilammentie 42",
             "postalcode": "02980"
           }
         ],
@@ -9197,7 +8760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuhkurinranta 10",
             "postalcode": "02980"
           }
         ],
@@ -9218,7 +8780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Salakkatie 9",
             "postalcode": "02170"
           }
         ],
@@ -9239,7 +8800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Haukilahdenkatu 6",
             "postalcode": "02170"
           }
         ],
@@ -9260,7 +8820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Loojärventie 13",
             "postalcode": "02780"
           }
         ],
@@ -9281,7 +8840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Toppelundinkuja 2",
             "postalcode": "02170"
           }
         ],
@@ -9302,7 +8860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tontunmäentie 34",
             "postalcode": "02200"
           }
         ],
@@ -9323,7 +8880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tontunmäentie 22",
             "postalcode": "02200"
           }
         ],
@@ -9344,7 +8900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Halujärventie 49",
             "postalcode": "02780"
           }
         ],
@@ -9365,7 +8920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jakoniityntie 9",
             "postalcode": "02780"
           }
         ],
@@ -9386,7 +8940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lyhdekuja 3",
             "postalcode": "02200"
           }
         ],
@@ -9407,7 +8960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tontunmäentie 16",
             "postalcode": "02200"
           }
         ],
@@ -9428,7 +8980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tallimestarintie 23",
             "postalcode": "02940"
           }
         ],
@@ -9449,7 +9000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sisäkönkuja 3",
             "postalcode": "02940"
           }
         ],
@@ -9470,7 +9020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riihitontuntie 12",
             "postalcode": "02200"
           }
         ],
@@ -9491,7 +9040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vääräjärventie 12",
             "postalcode": "02820"
           }
         ],
@@ -9512,7 +9060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vääräjärventie 12",
             "postalcode": "02820"
           }
         ],
@@ -9533,7 +9080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivuviidantie 20b",
             "postalcode": "02130"
           }
         ],
@@ -9554,7 +9100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Visakoivunkuja 6",
             "postalcode": "02130"
           }
         ],
@@ -9575,7 +9120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäniitynlaita 9",
             "postalcode": "02810"
           }
         ],
@@ -9596,7 +9140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rauduntie 31",
             "postalcode": "02130"
           }
         ],
@@ -9617,7 +9160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sepontie 1",
             "postalcode": "02130"
           }
         ],
@@ -9638,7 +9180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivunrunko 8",
             "postalcode": "02130"
           }
         ],
@@ -9659,7 +9200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ukonvaaja 1",
             "postalcode": "02130"
           }
         ],
@@ -9680,7 +9220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenkirkontie 4b",
             "postalcode": "02130"
           }
         ],
@@ -9701,7 +9240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suotorpantie 14",
             "postalcode": "02130"
           }
         ],
@@ -9722,7 +9260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivennavankuja 11",
             "postalcode": "02130"
           }
         ],
@@ -9743,7 +9280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lumivaarantie 6",
             "postalcode": "02140"
           }
         ],
@@ -9764,7 +9300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaukolantie 3",
             "postalcode": "02140"
           }
         ],
@@ -9785,7 +9320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirvuntie 29",
             "postalcode": "02140"
           }
         ],
@@ -9806,7 +9340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Alaportti 1",
             "postalcode": "02210"
           }
         ],
@@ -9827,7 +9360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajamäentie 12",
             "postalcode": "02780"
           }
         ],
@@ -9848,7 +9380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jaakkimantie 9",
             "postalcode": "02140"
           }
         ],
@@ -9869,7 +9400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaukolantie 34",
             "postalcode": "02140"
           }
         ],
@@ -9890,7 +9420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänkajontie 7",
             "postalcode": "02210"
           }
         ],
@@ -9911,7 +9440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Krenatöörintie 31",
             "postalcode": "02680"
           }
         ],
@@ -9932,7 +9460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koukkuniementie 17",
             "postalcode": "02230"
           }
         ],
@@ -9953,7 +9480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koukkuniemenkuja 1",
             "postalcode": "02230"
           }
         ],
@@ -9974,7 +9500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Selkänuotankuja 8",
             "postalcode": "02230"
           }
         ],
@@ -9995,7 +9520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nokkalankulma 7",
             "postalcode": "02230"
           }
         ],
@@ -10016,7 +9540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Seilikaari 5",
             "postalcode": "02180"
           }
         ],
@@ -10037,7 +9560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Seilikaari 8",
             "postalcode": "02180"
           }
         ],
@@ -10058,7 +9580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nokkalankulma 5",
             "postalcode": "02230"
           }
         ],
@@ -10079,7 +9600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lapionpisto 2",
             "postalcode": "02920"
           }
         ],
@@ -10100,7 +9620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paulakuja 5",
             "postalcode": "02230"
           }
         ],
@@ -10121,7 +9640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kluuvintie 4",
             "postalcode": "02180"
           }
         ],
@@ -10142,7 +9660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Katiskatie 1",
             "postalcode": "02230"
           }
         ],
@@ -10163,7 +9680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Parolantie 3",
             "postalcode": "02200"
           }
         ],
@@ -10184,7 +9700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Parolanrinne 8",
             "postalcode": "02200"
           }
         ],
@@ -10205,7 +9720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuottalahdentie 32",
             "postalcode": "02230"
           }
         ],
@@ -10226,7 +9740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Puntaritie 2",
             "postalcode": "02230"
           }
         ],
@@ -10247,7 +9760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nelikkokuja 6",
             "postalcode": "02230"
           }
         ],
@@ -10268,7 +9780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Matinkallio 7",
             "postalcode": "02230"
           }
         ],
@@ -10289,7 +9800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nelikkotie 12",
             "postalcode": "02230"
           }
         ],
@@ -10310,7 +9820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mankkaanpuro 25",
             "postalcode": "02180"
           }
         ],
@@ -10331,7 +9840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mankkaanpuro 11",
             "postalcode": "02180"
           }
         ],
@@ -10352,7 +9860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhan-Mankkaan tie 17",
             "postalcode": "02180"
           }
         ],
@@ -10373,7 +9880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lilla Blindsund",
             "postalcode": "02230"
           }
         ],
@@ -10394,7 +9900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenkylänmäki 23",
             "postalcode": "02750"
           }
         ],
@@ -10415,7 +9920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavinharju 6",
             "postalcode": "02180"
           }
         ],
@@ -10436,7 +9940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kruununrinne 1b",
             "postalcode": "02180"
           }
         ],
@@ -10457,7 +9960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavinsuo 7",
             "postalcode": "02180"
           }
         ],
@@ -10478,7 +9980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Klovinmäki 3",
             "postalcode": "02180"
           }
         ],
@@ -10499,7 +10000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taavinsuo 11",
             "postalcode": "02180"
           }
         ],
@@ -10520,7 +10020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suomalaistentie 4",
             "postalcode": "02270"
           }
         ],
@@ -10541,7 +10040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Martinniitty 4",
             "postalcode": "02270"
           }
         ],
@@ -10562,7 +10060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Martintie 12",
             "postalcode": "02270"
           }
         ],
@@ -10583,7 +10080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Martintie 12",
             "postalcode": "02270"
           }
         ],
@@ -10604,7 +10100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kattilalaaksonkatu 17",
             "postalcode": "02330"
           }
         ],
@@ -10625,7 +10120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Eestiläistentie 16",
             "postalcode": "02270"
           }
         ],
@@ -10646,7 +10140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajamäentie 21",
             "postalcode": "02330"
           }
         ],
@@ -10667,7 +10160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myötätuulenmäki 10",
             "postalcode": "02330"
           }
         ],
@@ -10688,7 +10180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Saunalahdentie 9",
             "postalcode": "02330"
           }
         ],
@@ -10709,7 +10200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suomalaistentie 8",
             "postalcode": "02270"
           }
         ],
@@ -10730,7 +10220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Eteläviitta 9",
             "postalcode": "02330"
           }
         ],
@@ -10751,7 +10240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nissinmäentie 1",
             "postalcode": "02780"
           }
         ],
@@ -10772,7 +10260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nissinmäentie 5a",
             "postalcode": "02780"
           }
         ],
@@ -10793,7 +10280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Oxfotintie 3",
             "postalcode": "02330"
           }
         ],
@@ -10814,7 +10300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nissinpuisto 5",
             "postalcode": "02780"
           }
         ],
@@ -10835,7 +10320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nissintie 9a",
             "postalcode": "02780"
           }
         ],
@@ -10856,7 +10340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenenportti 1",
             "postalcode": "02330"
           }
         ],
@@ -10877,7 +10360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenenportti 5",
             "postalcode": "02330"
           }
         ],
@@ -10898,7 +10380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vasikkakuja 8",
             "postalcode": "02330"
           }
         ],
@@ -10919,7 +10400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Satulamaakarintie 3",
             "postalcode": "02780"
           }
         ],
@@ -10940,7 +10420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peltomiehenkuja 2b",
             "postalcode": "02780"
           }
         ],
@@ -10961,7 +10440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pakarituvantie 3",
             "postalcode": "02780"
           }
         ],
@@ -10982,7 +10460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenenkallio 16",
             "postalcode": "02300"
           }
         ],
@@ -11003,7 +10480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peltomiehentie 7",
             "postalcode": "02780"
           }
         ],
@@ -11024,7 +10500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purotanhua 8",
             "postalcode": "02270"
           }
         ],
@@ -11045,7 +10520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tanhuanpää 12",
             "postalcode": "02270"
           }
         ],
@@ -11066,7 +10540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntykallio 4",
             "postalcode": "02270"
           }
         ],
@@ -11087,7 +10560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mesimäki 19",
             "postalcode": "02780"
           }
         ],
@@ -11108,7 +10580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hunajaportti 11",
             "postalcode": "02780"
           }
         ],
@@ -11129,7 +10600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hansakallio 4",
             "postalcode": "02780"
           }
         ],
@@ -11150,7 +10620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hansakallionkuja 3",
             "postalcode": "02780"
           }
         ],
@@ -11171,7 +10640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purotie 7",
             "postalcode": "02300"
           }
         ],
@@ -11192,7 +10660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korpikallio 15",
             "postalcode": "02300"
           }
         ],
@@ -11213,7 +10680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Retkikuja 1",
             "postalcode": "02300"
           }
         ],
@@ -11234,7 +10700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sisämaantie 2a",
             "postalcode": "02780"
           }
         ],
@@ -11255,7 +10720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korpisola 7",
             "postalcode": "02300"
           }
         ],
@@ -11276,7 +10740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaahteramäki 6",
             "postalcode": "02270"
           }
         ],
@@ -11297,7 +10760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ramsaynkuja 8",
             "postalcode": "02780"
           }
         ],
@@ -11318,7 +10780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nöykkiönpuro 5b",
             "postalcode": "02300"
           }
         ],
@@ -11339,7 +10800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Finnoontie 12",
             "postalcode": "02280"
           }
         ],
@@ -11360,7 +10820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Palttinapolku 6",
             "postalcode": "02780"
           }
         ],
@@ -11381,7 +10840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Eestinkallio 7",
             "postalcode": "02280"
           }
         ],
@@ -11402,7 +10860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Finnoontie 22",
             "postalcode": "02280"
           }
         ],
@@ -11423,7 +10880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lasilaakso 5",
             "postalcode": "02780"
           }
         ],
@@ -11444,7 +10900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kristallitie 11",
             "postalcode": "02780"
           }
         ],
@@ -11465,7 +10920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mickelsinkuja 5",
             "postalcode": "02770"
           }
         ],
@@ -11486,7 +10940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muuralanpiha 2",
             "postalcode": "02770"
           }
         ],
@@ -11507,7 +10960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulumestarinkuja 15",
             "postalcode": "02770"
           }
         ],
@@ -11528,7 +10980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koulumestarinkuja 4a",
             "postalcode": "02770"
           }
         ],
@@ -11549,7 +11000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Arvelanniitty 5",
             "postalcode": "02770"
           }
         ],
@@ -11570,7 +11020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kokkohongantie 12",
             "postalcode": "02340"
           }
         ],
@@ -11591,7 +11040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruiskaski 6",
             "postalcode": "02340"
           }
         ],
@@ -11612,7 +11060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaskihakkio 2",
             "postalcode": "02340"
           }
         ],
@@ -11633,7 +11080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurinjärventie 4",
             "postalcode": "02820"
           }
         ],
@@ -11654,7 +11100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Savikuja 1",
             "postalcode": "02770"
           }
         ],
@@ -11675,7 +11120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruukkukuja 2",
             "postalcode": "02770"
           }
         ],
@@ -11696,7 +11140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pellavakaski 28",
             "postalcode": "02340"
           }
         ],
@@ -11717,7 +11160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukkaromäki 3",
             "postalcode": "02770"
           }
         ],
@@ -11738,7 +11180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riksikuja 7",
             "postalcode": "02770"
           }
         ],
@@ -11759,7 +11200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nauriskaski 11",
             "postalcode": "02340"
           }
         ],
@@ -11780,7 +11220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ohrakaskensyrjä 6-8",
             "postalcode": "02340"
           }
         ],
@@ -11801,7 +11240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riksikuja 15",
             "postalcode": "02770"
           }
         ],
@@ -11822,7 +11260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kulkurinmäki 6",
             "postalcode": "02770"
           }
         ],
@@ -11843,7 +11280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustarinne 6",
             "postalcode": "02770"
           }
         ],
@@ -11864,7 +11300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kantokaski 13a",
             "postalcode": "02340"
           }
         ],
@@ -11885,7 +11320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehtikaskentie 22",
             "postalcode": "02340"
           }
         ],
@@ -11906,7 +11340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Puolarkuja 6",
             "postalcode": "02280"
           }
         ],
@@ -11927,7 +11360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Peltokumpu 4",
             "postalcode": "02280"
           }
         ],
@@ -11948,7 +11380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminhaka 8",
             "postalcode": "02280"
           }
         ],
@@ -11969,7 +11400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukkumäenkuja 12",
             "postalcode": "02280"
           }
         ],
@@ -11990,7 +11420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukkumäenrinne 8",
             "postalcode": "02280"
           }
         ],
@@ -12011,7 +11440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kukkumäenrinne 16",
             "postalcode": "02280"
           }
         ],
@@ -12032,7 +11460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminmäentie 2",
             "postalcode": "02280"
           }
         ],
@@ -12053,7 +11480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminmäentie 1",
             "postalcode": "02280"
           }
         ],
@@ -12074,7 +11500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Espoontie 16",
             "postalcode": "02770"
           }
         ],
@@ -12095,7 +11520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Espoontie 16",
             "postalcode": "02770"
           }
         ],
@@ -12116,7 +11540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Espoontie 12",
             "postalcode": "02770"
           }
         ],
@@ -12137,7 +11560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muuralanportti 10",
             "postalcode": "02770"
           }
         ],
@@ -12158,7 +11580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muuralankumpu 2",
             "postalcode": "02770"
           }
         ],
@@ -12179,7 +11600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nimismiehenmäki 3",
             "postalcode": "02770"
           }
         ],
@@ -12200,7 +11620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lakitie 4",
             "postalcode": "02770"
           }
         ],
@@ -12221,7 +11640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kappalaisenkuja 1",
             "postalcode": "02940"
           }
         ],
@@ -12242,7 +11660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Raitakuja 3",
             "postalcode": "02940"
           }
         ],
@@ -12263,7 +11680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajatertuntie 2",
             "postalcode": "02940"
           }
         ],
@@ -12284,7 +11700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajatertuntie 6c",
             "postalcode": "02940"
           }
         ],
@@ -12305,7 +11720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajapuuntie 6",
             "postalcode": "02940"
           }
         ],
@@ -12326,7 +11740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajamarjantie 16",
             "postalcode": "02940"
           }
         ],
@@ -12347,7 +11760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Auroranmäki 2",
             "postalcode": "02940"
           }
         ],
@@ -12368,7 +11780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aurorankuja 3",
             "postalcode": "02940"
           }
         ],
@@ -12389,7 +11800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soihtukuja 11",
             "postalcode": "02940"
           }
         ],
@@ -12410,7 +11820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Soihtukaari 26",
             "postalcode": "02940"
           }
         ],
@@ -12431,7 +11840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kavaljeerinkuja 12",
             "postalcode": "02940"
           }
         ],
@@ -12452,7 +11860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Porrastie 5",
             "postalcode": "02330"
           }
         ],
@@ -12473,7 +11880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Maakirjantie 16",
             "postalcode": "02250"
           }
         ],
@@ -12494,7 +11900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Välimetsä 6",
             "postalcode": "02300"
           }
         ],
@@ -12515,7 +11920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heimolantie 9",
             "postalcode": "02330"
           }
         ],
@@ -12536,7 +11940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heimolantie 22",
             "postalcode": "02330"
           }
         ],
@@ -12557,7 +11960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Saunarinne 1",
             "postalcode": "02330"
           }
         ],
@@ -12578,7 +11980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähän-Myntin tie 4",
             "postalcode": "02780"
           }
         ],
@@ -12599,7 +12000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myntinmäki 1",
             "postalcode": "02780"
           }
         ],
@@ -12620,7 +12020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mynttiläntie",
             "postalcode": "02780"
           }
         ],
@@ -12641,7 +12040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hylkeenpyytäjäntie 5",
             "postalcode": "02270"
           }
         ],
@@ -12662,7 +12060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Neljäskuja 2",
             "postalcode": "02620"
           }
         ],
@@ -12683,7 +12080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Varaväentie 9",
             "postalcode": "02680"
           }
         ],
@@ -12704,7 +12100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veteraaninkuja 3",
             "postalcode": "02680"
           }
         ],
@@ -12725,7 +12120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotilastorpantie 7",
             "postalcode": "02680"
           }
         ],
@@ -12746,7 +12140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muskettitie 34",
             "postalcode": "02680"
           }
         ],
@@ -12767,7 +12160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Muskettitie 25",
             "postalcode": "02680"
           }
         ],
@@ -12788,7 +12180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koukkuniemenportti 1",
             "postalcode": "02230"
           }
         ],
@@ -12809,7 +12200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sotaleskentie 10",
             "postalcode": "02650"
           }
         ],
@@ -12830,7 +12220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Loojärventie 38",
             "postalcode": "02780"
           }
         ],
@@ -12851,7 +12240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Matkalaisenkuja 3",
             "postalcode": "02940"
           }
         ],
@@ -12872,7 +12260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Solvikintie 40",
             "postalcode": "02820"
           }
         ],
@@ -12893,7 +12280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aamukuja 5b",
             "postalcode": "02200"
           }
         ],
@@ -12914,7 +12300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Träskkopplan",
             "postalcode": "02380"
           }
         ],
@@ -12935,7 +12320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Högkopplan",
             "postalcode": "02380"
           }
         ],
@@ -12956,7 +12340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hauklammenranta 12",
             "postalcode": "02820"
           }
         ],
@@ -12977,7 +12360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kattilajärventie",
             "postalcode": "02820"
           }
         ],
@@ -12998,7 +12380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Stora Herrö",
             "postalcode": "02380"
           }
         ],
@@ -13019,7 +12400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mankholmantie 3",
             "postalcode": "02380"
           }
         ],
@@ -13040,7 +12420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rauhamäenkuja 12",
             "postalcode": "02820"
           }
         ],
@@ -13061,7 +12440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Uudenpellonkuja 11",
             "postalcode": "02860"
           }
         ],
@@ -13082,7 +12460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pentala",
             "postalcode": "02380"
           }
         ],
@@ -13103,7 +12480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nuuksiontie 20",
             "postalcode": "02820"
           }
         ],
@@ -13124,7 +12500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suvisaarentie 12",
             "postalcode": "02380"
           }
         ],
@@ -13145,7 +12520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Felsundintie 4",
             "postalcode": "02380"
           }
         ],
@@ -13166,7 +12540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vaahteratie 8b",
             "postalcode": "02270"
           }
         ],
@@ -13187,7 +12560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mellilänkuja 7",
             "postalcode": "02380"
           }
         ],
@@ -13208,7 +12580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tallholmantie 8",
             "postalcode": "02380"
           }
         ],
@@ -13229,7 +12600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tyskaksentie 10",
             "postalcode": "02330"
           }
         ],
@@ -13250,7 +12620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tyskaksentie 10",
             "postalcode": "02330"
           }
         ],
@@ -13271,7 +12640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kattilarinne 11",
             "postalcode": "02330"
           }
         ],
@@ -13292,7 +12660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruisrääkäntie 1",
             "postalcode": "02660"
           }
         ],
@@ -13313,7 +12680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruisrääkäntie 21",
             "postalcode": "02660"
           }
         ],
@@ -13334,7 +12700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintumetsäntie 9",
             "postalcode": "02660"
           }
         ],
@@ -13355,7 +12720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintumetsäntie 9",
             "postalcode": "02660"
           }
         ],
@@ -13376,7 +12740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintuparvenkuja 3",
             "postalcode": "02660"
           }
         ],
@@ -13397,7 +12760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivälinnuntie 4",
             "postalcode": "02660"
           }
         ],
@@ -13418,7 +12780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintukorpi 10",
             "postalcode": "02660"
           }
         ],
@@ -13439,7 +12800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Joel Rundtin tie 3",
             "postalcode": "02600"
           }
         ],
@@ -13460,7 +12820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hämeenkyläntie 58",
             "postalcode": "02660"
           }
         ],
@@ -13481,7 +12840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jääskeläntie 35",
             "postalcode": "02660"
           }
         ],
@@ -13502,7 +12860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruukinrannantie 5",
             "postalcode": "02600"
           }
         ],
@@ -13523,7 +12880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Salakkatie 12",
             "postalcode": "02170"
           }
         ],
@@ -13544,7 +12900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Degerbyntie 8",
             "postalcode": "02600"
           }
         ],
@@ -13565,7 +12920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rautiaisentie 4b",
             "postalcode": "02660"
           }
         ],
@@ -13586,7 +12940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Väli-Henttaan tie 18",
             "postalcode": "02250"
           }
         ],
@@ -13607,7 +12960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nupurinjärventie 2",
             "postalcode": "02820"
           }
         ],
@@ -13628,7 +12980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kanneljärventie 15",
             "postalcode": "02130"
           }
         ],
@@ -13649,7 +13000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Invalidintie 12",
             "postalcode": "02650"
           }
         ],
@@ -13670,7 +13020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuitinkuja 4",
             "postalcode": "02210"
           }
         ],
@@ -13691,7 +13040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keskiyöntie 9",
             "postalcode": "02210"
           }
         ],
@@ -13712,7 +13060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aamuyöntie 13",
             "postalcode": "02210"
           }
         ],
@@ -13733,7 +13080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Iltapäiväntie 12",
             "postalcode": "02210"
           }
         ],
@@ -13754,7 +13100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aamupäivänkuja 2",
             "postalcode": "02210"
           }
         ],
@@ -13775,7 +13120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Isoistenkuja 6",
             "postalcode": "02200"
           }
         ],
@@ -13796,7 +13140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalenteritie 18-20",
             "postalcode": "02200"
           }
         ],
@@ -13817,7 +13160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viikkokuja 3",
             "postalcode": "02200"
           }
         ],
@@ -13838,7 +13180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hanikka 45",
             "postalcode": "02360"
           }
         ],
@@ -13859,7 +13200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Friisinniitty 5b",
             "postalcode": "02240"
           }
         ],
@@ -13880,7 +13220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Piispanmäenkuja 2",
             "postalcode": "02240"
           }
         ],
@@ -13901,7 +13240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivitie 22b",
             "postalcode": "02240"
           }
         ],
@@ -13922,7 +13260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Friisiläntie 37",
             "postalcode": "02240"
           }
         ],
@@ -13943,7 +13280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Holmanmäki 10",
             "postalcode": "02240"
           }
         ],
@@ -13964,7 +13300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Holmanpää 5",
             "postalcode": "02240"
           }
         ],
@@ -13985,7 +13320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinkkitie 11",
             "postalcode": "02750"
           }
         ],
@@ -14006,7 +13340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tähdenlennontie 12b",
             "postalcode": "02240"
           }
         ],
@@ -14027,7 +13360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Turuntie 150",
             "postalcode": "02740"
           }
         ],
@@ -14048,7 +13380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiistinniityntie 1",
             "postalcode": "02230"
           }
         ],
@@ -14069,7 +13400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkäniitynlaita 2",
             "postalcode": "02810"
           }
         ],
@@ -14090,7 +13420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kalastajankuja 5",
             "postalcode": "02230"
           }
         ],
@@ -14111,7 +13440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiistinkallio 6",
             "postalcode": "02230"
           }
         ],
@@ -14132,7 +13460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Verkkokuja 1b",
             "postalcode": "02230"
           }
         ],
@@ -14153,7 +13480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Iirislahdentie 41b",
             "postalcode": "02230"
           }
         ],
@@ -14174,7 +13500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lugnetinniitty 5b",
             "postalcode": "02770"
           }
         ],
@@ -14195,7 +13520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marinsatamantie 3",
             "postalcode": "02320"
           }
         ],
@@ -14216,7 +13540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Matkalaisenkuja 1",
             "postalcode": "02940"
           }
         ],
@@ -14237,7 +13560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kirkkoharju 7",
             "postalcode": "02330"
           }
         ],
@@ -14258,7 +13580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuninkaankartanontie 46a",
             "postalcode": "02780"
           }
         ],
@@ -14279,7 +13600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rajanummi 9",
             "postalcode": "02940"
           }
         ],
@@ -14300,7 +13620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nöykkiönlaaksontie 42",
             "postalcode": "02330"
           }
         ],
@@ -14321,7 +13640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitkännotkontie 43a",
             "postalcode": "02750"
           }
         ],
@@ -14342,7 +13660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nahkasuutarintie 7",
             "postalcode": "02780"
           }
         ],
@@ -14363,7 +13680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Bosmedsinkuja 6",
             "postalcode": "02940"
           }
         ],
@@ -14384,7 +13700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihkametsä 2",
             "postalcode": "02740"
           }
         ],
@@ -14405,7 +13720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kattilavuorentie 16",
             "postalcode": "02330"
           }
         ],
@@ -14426,7 +13740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Merituulentie 11",
             "postalcode": "02100"
           }
         ],
@@ -14447,7 +13760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Finnoontie 32",
             "postalcode": "02280"
           }
         ],
@@ -14468,7 +13780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tervamäki 4",
             "postalcode": "02810"
           }
         ],
@@ -14489,7 +13800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purolaakso 26b",
             "postalcode": "02920"
           }
         ],
@@ -14510,7 +13820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Heikunantie 4",
             "postalcode": "02680"
           }
         ],
@@ -14531,7 +13840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kelkkamäki 1",
             "postalcode": "02610"
           }
         ],
@@ -14552,7 +13860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuurinniityntie 9",
             "postalcode": "02250"
           }
         ],
@@ -14573,7 +13880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuurinmäki 1",
             "postalcode": "02750"
           }
         ],
@@ -14594,7 +13900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kangaskatu 2",
             "postalcode": "02780"
           }
         ],
@@ -14615,7 +13920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laaksolahdentie 106",
             "postalcode": "02730"
           }
         ],
@@ -14636,7 +13940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rantakatu 7",
             "postalcode": "10900"
           }
         ],
@@ -14657,7 +13960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Merikatu 1",
             "postalcode": "10900"
           }
         ],
@@ -14678,7 +13980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ratakatu 12-14",
             "postalcode": "10900"
           }
         ],
@@ -14699,7 +14000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perämiehenkatu 26",
             "postalcode": "10900"
           }
         ],
@@ -14720,7 +14020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Käsityöläiskatu 20",
             "postalcode": "10960"
           }
         ],
@@ -14741,7 +14040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Santalantie 15",
             "postalcode": "10960"
           }
         ],
@@ -14762,7 +14060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jarrumiehenkatu 24",
             "postalcode": "10960"
           }
         ],
@@ -14783,7 +14080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kappelisatamantie 160",
             "postalcode": "10960"
           }
         ],
@@ -14804,7 +14100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nosturintie 1-3",
             "postalcode": "10960"
           }
         ],
@@ -14825,7 +14120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veturinkuljettajankatu 28",
             "postalcode": "10900"
           }
         ],
@@ -14846,7 +14140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Täktomintie 252",
             "postalcode": "10900"
           }
         ],
@@ -14867,7 +14160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lasitehtaankatu 4-6",
             "postalcode": "10960"
           }
         ],
@@ -14888,7 +14180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veturinkuljettajankatu 25",
             "postalcode": "10960"
           }
         ],
@@ -14909,7 +14200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rauhankatu 13",
             "postalcode": "10900"
           }
         ],
@@ -14930,7 +14220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Asemakatu 14",
             "postalcode": "10900"
           }
         ],
@@ -14951,7 +14240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Narvikinkatu 13",
             "postalcode": "10900"
           }
         ],
@@ -14972,7 +14260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Raatimiehenkatu 6",
             "postalcode": "10900"
           }
         ],
@@ -14993,7 +14280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linjakatu 10",
             "postalcode": "10900"
           }
         ],
@@ -15014,7 +14300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linjakatu 20",
             "postalcode": "10900"
           }
         ],
@@ -15035,7 +14320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kivenhakkaajankatu 11",
             "postalcode": "10900"
           }
         ],
@@ -15056,7 +14340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiilitehtaantie 2",
             "postalcode": "10900"
           }
         ],
@@ -15077,7 +14360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Norrgårdinkatu 23",
             "postalcode": "10940"
           }
         ],
@@ -15098,7 +14380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiilitehtaantie 9",
             "postalcode": "10900"
           }
         ],
@@ -15119,7 +14400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulliniementie 4",
             "postalcode": "10940"
           }
         ],
@@ -15140,7 +14420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulliniementie 9",
             "postalcode": "10940"
           }
         ],
@@ -15161,7 +14440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Gunnarsinkatu 2",
             "postalcode": "10940"
           }
         ],
@@ -15182,7 +14460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kappelisatamantie 10",
             "postalcode": "10940"
           }
         ],
@@ -15203,7 +14480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Varisniemi 6",
             "postalcode": "10900"
           }
         ],
@@ -15224,7 +14500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laivurinkatu 39",
             "postalcode": "10940"
           }
         ],
@@ -15245,7 +14520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Länsiseläntie 11a",
             "postalcode": "10940"
           }
         ],
@@ -15266,7 +14540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsäkannaksentie 36",
             "postalcode": "10940"
           }
         ],
@@ -15287,7 +14560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Metsäkannaksentie 19",
             "postalcode": "10940"
           }
         ],
@@ -15308,7 +14580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Haukikuja 7",
             "postalcode": "10900"
           }
         ],
@@ -15329,7 +14600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nummitie 18",
             "postalcode": "10960"
           }
         ],
@@ -15350,7 +14620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Teollisuuskatu 1",
             "postalcode": "10960"
           }
         ],
@@ -15371,7 +14640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riskiläntie 6",
             "postalcode": "10960"
           }
         ],
@@ -15392,7 +14660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ruusukuja 4",
             "postalcode": "10900"
           }
         ],
@@ -15413,7 +14680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Emelienpolku 3",
             "postalcode": "10960"
           }
         ],
@@ -15434,7 +14700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Bergenheimintie 5",
             "postalcode": "10960"
           }
         ],
@@ -15455,7 +14720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fundia Wire Oy",
             "postalcode": "10820"
           }
         ],
@@ -15476,7 +14740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sinterilaitos",
             "postalcode": "10900"
           }
         ],
@@ -15497,7 +14760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Svanvik",
             "postalcode": "10900"
           }
         ],
@@ -15518,7 +14780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Venny Soldanin tie 1",
             "postalcode": "10900"
           }
         ],
@@ -15539,7 +14800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tvärminne",
             "postalcode": "10900"
           }
         ],
@@ -15560,7 +14820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Topeliuksentie 1",
             "postalcode": "10900"
           }
         ],
@@ -15581,7 +14840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Krialskär",
             "postalcode": "10900"
           }
         ],
@@ -15602,7 +14860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Täktomintie 737",
             "postalcode": "10900"
           }
         ],
@@ -15623,7 +14880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Täktomintie 530",
             "postalcode": "10900"
           }
         ],
@@ -15644,7 +14900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koivukaari 25",
             "postalcode": "10960"
           }
         ],
@@ -15665,7 +14920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Långörintie 24",
             "postalcode": "10900"
           }
         ],
@@ -15686,7 +14940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Söderbonäs",
             "postalcode": "10820"
           }
         ],
@@ -15707,7 +14960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Krogars",
             "postalcode": "10820"
           }
         ],
@@ -15728,7 +14980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lappvikin Kartanontie 127",
             "postalcode": "10820"
           }
         ],
@@ -15749,7 +15000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajakuja 3",
             "postalcode": "10820"
           }
         ],
@@ -15770,7 +15020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pihlajakuja 1",
             "postalcode": "10820"
           }
         ],
@@ -15791,7 +15040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Satamatie 34",
             "postalcode": "10820"
           }
         ],
@@ -15812,7 +15060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lasitehtaankatu 5",
             "postalcode": "10960"
           }
         ],
@@ -15833,7 +15080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tennbergintie 21",
             "postalcode": "10820"
           }
         ],
@@ -15854,7 +15100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kävelykuja 8",
             "postalcode": "10820"
           }
         ],
@@ -15875,7 +15120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ekö",
             "postalcode": "10820"
           }
         ],
@@ -15896,7 +15140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sällvik",
             "postalcode": "10900"
           }
         ],
@@ -15917,7 +15160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulliniemi Luotsiasema",
             "postalcode": "10900"
           }
         ],
@@ -15938,7 +15180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vapaasatama",
             "postalcode": "10940"
           }
         ],
@@ -15959,7 +15200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sibeliuksentie 27 b",
             "postalcode": "10900"
           }
         ],
@@ -15980,7 +15220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Halkaisijantie 6",
             "postalcode": "00980"
           }
         ],
@@ -16001,7 +15240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuotie 19",
             "postalcode": "00980"
           }
         ],
@@ -16022,7 +15260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Meri-Rastilan tie 21",
             "postalcode": "00980"
           }
         ],
@@ -16043,7 +15280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Meri-Rastilan tie 15",
             "postalcode": "00980"
           }
         ],
@@ -16064,7 +15300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Verkkotie 10",
             "postalcode": "00980"
           }
         ],
@@ -16085,7 +15320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Verkkopolku 4",
             "postalcode": "00980"
           }
         ],
@@ -16106,7 +15340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marielundin puistotie 6",
             "postalcode": "00960"
           }
         ],
@@ -16127,7 +15360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhankallionkuja 1",
             "postalcode": "00990"
           }
         ],
@@ -16148,7 +15380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Gustav Pauligin katu 15",
             "postalcode": "00990"
           }
         ],
@@ -16169,7 +15400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhankallionkuja 2",
             "postalcode": "00990"
           }
         ],
@@ -16190,7 +15420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nukkeruusunkuja 4",
             "postalcode": "00990"
           }
         ],
@@ -16211,7 +15440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Käärmeniementie 11",
             "postalcode": "00990"
           }
         ],
@@ -16232,7 +15460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korsnäsintie 12",
             "postalcode": "00890"
           }
         ],
@@ -16253,7 +15480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mielikinpolku 1b",
             "postalcode": "00750"
           }
         ],
@@ -16274,7 +15500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kiitäjäntienpää",
             "postalcode": "00750"
           }
         ],
@@ -16295,7 +15520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vannetie 39",
             "postalcode": "00430"
           }
         ],
@@ -16316,7 +15540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pannipolku 8",
             "postalcode": "00430"
           }
         ],
@@ -16337,7 +15560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vakkatie 16",
             "postalcode": "00430"
           }
         ],
@@ -16358,7 +15580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Arhipanpolku 6b",
             "postalcode": "00420"
           }
         ],
@@ -16379,7 +15600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Hämeenkyläntie 29",
             "postalcode": "00390"
           }
         ],
@@ -16400,7 +15620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vähäniityntie 11",
             "postalcode": "00570"
           }
         ],
@@ -16421,7 +15640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ratapihantie 6",
             "postalcode": "00520"
           }
         ],
@@ -16442,7 +15660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Villinki",
             "postalcode": "00850"
           }
         ],
@@ -16463,7 +15680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Villinki Nmky",
             "postalcode": "00850"
           }
         ],
@@ -16484,7 +15700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keulakuvantie 18",
             "postalcode": "00840"
           }
         ],
@@ -16505,7 +15720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kuvuntie 2",
             "postalcode": "00860"
           }
         ],
@@ -16526,7 +15740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Villinki Safa",
             "postalcode": "00850"
           }
         ],
@@ -16547,7 +15760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fregattitie 5",
             "postalcode": "00850"
           }
         ],
@@ -16568,7 +15780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fregattitie 10",
             "postalcode": "00850"
           }
         ],
@@ -16589,7 +15800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laitamyötäisentie 2b",
             "postalcode": "00850"
           }
         ],
@@ -16610,7 +15820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Purjetuulenkuja 9",
             "postalcode": "00850"
           }
         ],
@@ -16631,7 +15840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Saunalahti (Laajasalo)",
             "postalcode": "00850"
           }
         ],
@@ -16652,7 +15860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hapero 8",
             "postalcode": "00760"
           }
         ],
@@ -16673,7 +15880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vartiosaari Lisebo",
             "postalcode": "00830"
           }
         ],
@@ -16694,7 +15900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vartiosaari",
             "postalcode": "00830"
           }
         ],
@@ -16715,7 +15920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnanrakentajantie 14",
             "postalcode": "00810"
           }
         ],
@@ -16736,7 +15940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallkullan kartano rak 1",
             "postalcode": "00730"
           }
         ],
@@ -16757,7 +15960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Askartie 16",
             "postalcode": "00700"
           }
         ],
@@ -16778,7 +15980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mesipuu 1b",
             "postalcode": "00750"
           }
         ],
@@ -16799,7 +16000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Otavantie 3",
             "postalcode": "00200"
           }
         ],
@@ -16820,7 +16020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäntysaari",
             "postalcode": "00200"
           }
         ],
@@ -16841,7 +16040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Alppikylänkuja 7",
             "postalcode": "00770"
           }
         ],
@@ -16862,7 +16060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myllyväenkatu 9",
             "postalcode": "00920"
           }
         ],
@@ -16883,7 +16080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiidenmaankatu 6e",
             "postalcode": "00980"
           }
         ],
@@ -16904,7 +16100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ulvilantie 29 Rak 7",
             "postalcode": "00350"
           }
         ],
@@ -16925,7 +16120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ulvilantie 26",
             "postalcode": "00350"
           }
         ],
@@ -16946,7 +16140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taiteentekijäntie 7",
             "postalcode": "00350"
           }
         ],
@@ -16967,7 +16160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mesenaatintie 6",
             "postalcode": "00350"
           }
         ],
@@ -16988,7 +16180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rödje-Fantsin tie 19",
             "postalcode": "00890"
           }
         ],
@@ -17009,7 +16200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rödje-Fantsin tie 19",
             "postalcode": "00890"
           }
         ],
@@ -17030,7 +16220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koillisväylä 15",
             "postalcode": "00200"
           }
         ],
@@ -17051,7 +16240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korsnäsintie 17",
             "postalcode": "00890"
           }
         ],
@@ -17072,7 +16260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhutorpantie",
             "postalcode": "00890"
           }
         ],
@@ -17093,7 +16280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Luotsinkuja 2",
             "postalcode": "00890"
           }
         ],
@@ -17114,7 +16300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Merikapteenintie 13",
             "postalcode": "00890"
           }
         ],
@@ -17135,7 +16320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Myllykalliontie 3",
             "postalcode": "00200"
           }
         ],
@@ -17156,7 +16340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhurannankuja 2",
             "postalcode": "00890"
           }
         ],
@@ -17177,7 +16360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kapteenintie 16",
             "postalcode": "00890"
           }
         ],
@@ -17198,7 +16380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vattuniemenkuja 3",
             "postalcode": "00210"
           }
         ],
@@ -17219,7 +16400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Isonniityntie 22",
             "postalcode": "00890"
           }
         ],
@@ -17240,7 +16420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Melkonkuja 4",
             "postalcode": "00210"
           }
         ],
@@ -17261,7 +16440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veneentekijänkaari 9",
             "postalcode": "00210"
           }
         ],
@@ -17282,7 +16460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaskisaarentie 9",
             "postalcode": "00340"
           }
         ],
@@ -17303,7 +16480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaskiauranpolku 7",
             "postalcode": "00340"
           }
         ],
@@ -17324,7 +16500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhunevantie 14",
             "postalcode": "00890"
           }
         ],
@@ -17345,7 +16520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhunevanpolku 2",
             "postalcode": "00890"
           }
         ],
@@ -17366,7 +16540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kyntäjäntie 18c",
             "postalcode": "00390"
           }
         ],
@@ -17387,7 +16560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kappelintie 33",
             "postalcode": "00890"
           }
         ],
@@ -17408,7 +16580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sänkikuja 1",
             "postalcode": "00390"
           }
         ],
@@ -17429,7 +16600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hilatie 21",
             "postalcode": "00390"
           }
         ],
@@ -17450,7 +16620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Riukutie 3",
             "postalcode": "00390"
           }
         ],
@@ -17471,7 +16640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vitsastie 7",
             "postalcode": "00390"
           }
         ],
@@ -17492,7 +16660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lehtovuorenkatu 9",
             "postalcode": "00390"
           }
         ],
@@ -17513,7 +16680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaarelankuja 3a",
             "postalcode": "00430"
           }
         ],
@@ -17534,7 +16700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaarelantie 20a",
             "postalcode": "00430"
           }
         ],
@@ -17555,7 +16720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Maavallintie 7b",
             "postalcode": "00430"
           }
         ],
@@ -17576,7 +16740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lavettitie 16",
             "postalcode": "00430"
           }
         ],
@@ -17597,7 +16760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuorilinnakkeenpolku 3",
             "postalcode": "00430"
           }
         ],
@@ -17618,7 +16780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Maununnevantie 11a",
             "postalcode": "00430"
           }
         ],
@@ -17639,7 +16800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Juoksuhaudantie 10",
             "postalcode": "00430"
           }
         ],
@@ -17660,7 +16820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Juoksuhaudantie 12a",
             "postalcode": "00430"
           }
         ],
@@ -17681,7 +16840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Maljatie 3",
             "postalcode": "00430"
           }
         ],
@@ -17702,7 +16860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Liikkalantie 10",
             "postalcode": "00950"
           }
         ],
@@ -17723,7 +16880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vannetie 57a",
             "postalcode": "00430"
           }
         ],
@@ -17744,7 +16900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Posetiivarinkuja 10",
             "postalcode": "00420"
           }
         ],
@@ -17765,7 +16920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Runonlaulajantie 58b",
             "postalcode": "00420"
           }
         ],
@@ -17786,7 +16940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Arhipanpolku 8a",
             "postalcode": "00420"
           }
         ],
@@ -17807,7 +16960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Arhipanpolku 3",
             "postalcode": "00420"
           }
         ],
@@ -17828,7 +16980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Runonlaulajantie 68a",
             "postalcode": "00420"
           }
         ],
@@ -17849,7 +17000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kanuunatie 13",
             "postalcode": "00430"
           }
         ],
@@ -17870,7 +17020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Paimenhuilunpolku 12",
             "postalcode": "00420"
           }
         ],
@@ -17891,7 +17040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Raitamaantie 11",
             "postalcode": "00420"
           }
         ],
@@ -17912,7 +17060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laulukuja 6",
             "postalcode": "00420"
           }
         ],
@@ -17933,7 +17080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viulutie 7",
             "postalcode": "00420"
           }
         ],
@@ -17954,7 +17100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kartanonvoudintie 7",
             "postalcode": "00410"
           }
         ],
@@ -17975,7 +17120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koskustie 2",
             "postalcode": "00410"
           }
         ],
@@ -17996,7 +17140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Koskustie 5",
             "postalcode": "00410"
           }
         ],
@@ -18017,7 +17160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Naava-Aukio 4",
             "postalcode": "00410"
           }
         ],
@@ -18038,7 +17180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Urputie 10",
             "postalcode": "00410"
           }
         ],
@@ -18059,7 +17200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rukkilantie 3",
             "postalcode": "00410"
           }
         ],
@@ -18080,7 +17220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rukkilanrinne 1",
             "postalcode": "00410"
           }
         ],
@@ -18101,7 +17240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehruutie 3",
             "postalcode": "00410"
           }
         ],
@@ -18122,7 +17260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perhekunnantie 4",
             "postalcode": "00430"
           }
         ],
@@ -18143,7 +17280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perhekunnantie 4",
             "postalcode": "00430"
           }
         ],
@@ -18164,7 +17300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Perhekunnantie 14-20",
             "postalcode": "00430"
           }
         ],
@@ -18185,7 +17320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Serkustentie 1",
             "postalcode": "00430"
           }
         ],
@@ -18206,7 +17340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Serkustentie 18",
             "postalcode": "00430"
           }
         ],
@@ -18227,7 +17360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanhempientie 5",
             "postalcode": "00430"
           }
         ],
@@ -18248,7 +17380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaarelantie 6a",
             "postalcode": "00430"
           }
         ],
@@ -18269,7 +17400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotipellontie 9",
             "postalcode": "00680"
           }
         ],
@@ -18290,7 +17420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Henrik Lättiläisen katu 11",
             "postalcode": "00710"
           }
         ],
@@ -18311,7 +17440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Taulutie 12",
             "postalcode": "00680"
           }
         ],
@@ -18332,7 +17460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Klaukkalankuja 1",
             "postalcode": "00680"
           }
         ],
@@ -18353,7 +17480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Urkurintie 3",
             "postalcode": "00680"
           }
         ],
@@ -18374,7 +17500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Piikinkuja 5",
             "postalcode": "00680"
           }
         ],
@@ -18395,7 +17520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Opettajankuja 4",
             "postalcode": "00680"
           }
         ],
@@ -18416,7 +17540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Spelttitie 4",
             "postalcode": "00680"
           }
         ],
@@ -18437,7 +17560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jakokunnantie 8",
             "postalcode": "00660"
           }
         ],
@@ -18458,7 +17580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ervastinkuja 8",
             "postalcode": "00660"
           }
         ],
@@ -18479,7 +17600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päivänsalontie 3",
             "postalcode": "00660"
           }
         ],
@@ -18500,7 +17620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Alkutie 65",
             "postalcode": "00660"
           }
         ],
@@ -18521,7 +17640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suezinkatu 1",
             "postalcode": "00220"
           }
         ],
@@ -18542,7 +17660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suezinkatu 3",
             "postalcode": "00220"
           }
         ],
@@ -18563,7 +17680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Valssiparinkuja 5",
             "postalcode": "00920"
           }
         ],
@@ -18584,7 +17700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Asteritie 6",
             "postalcode": "00720"
           }
         ],
@@ -18605,7 +17720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kehäkukantie 7",
             "postalcode": "00720"
           }
         ],
@@ -18626,7 +17740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuohikuja 2",
             "postalcode": "00780"
           }
         ],
@@ -18647,7 +17760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Puroniitynpolku 6",
             "postalcode": "00720"
           }
         ],
@@ -18668,7 +17780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanha Puroniitynpolku 2",
             "postalcode": "00720"
           }
         ],
@@ -18689,7 +17800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vuolukiventie 1a",
             "postalcode": "00710"
           }
         ],
@@ -18710,7 +17820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Graniittitie 1",
             "postalcode": "00710"
           }
         ],
@@ -18731,7 +17840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rapakivenkuja 1",
             "postalcode": "00710"
           }
         ],
@@ -18752,7 +17860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Latokartanontie 37",
             "postalcode": "00710"
           }
         ],
@@ -18773,7 +17880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pekanraitti 22",
             "postalcode": "00700"
           }
         ],
@@ -18794,7 +17900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pekanraitti 22",
             "postalcode": "00700"
           }
         ],
@@ -18815,7 +17920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ormusrinne 2",
             "postalcode": "00700"
           }
         ],
@@ -18836,7 +17940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Malminkaari 27a",
             "postalcode": "00700"
           }
         ],
@@ -18857,7 +17960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vattuniemenkatu 17",
             "postalcode": "00210"
           }
         ],
@@ -18878,7 +17980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kaupparaitti 13",
             "postalcode": "00700"
           }
         ],
@@ -18899,7 +18000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotinummentie 8",
             "postalcode": "00700"
           }
         ],
@@ -18920,7 +18020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tukkisillantie 1",
             "postalcode": "00700"
           }
         ],
@@ -18941,7 +18040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Laidunkuja 5",
             "postalcode": "00700"
           }
         ],
@@ -18962,7 +18060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vainiotie 20b",
             "postalcode": "00700"
           }
         ],
@@ -18983,7 +18080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pilvitie 6a",
             "postalcode": "00700"
           }
         ],
@@ -19004,7 +18100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuulitie 4",
             "postalcode": "00700"
           }
         ],
@@ -19025,7 +18120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuulitie 3",
             "postalcode": "00700"
           }
         ],
@@ -19046,7 +18140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Raekuja 3",
             "postalcode": "00700"
           }
         ],
@@ -19067,7 +18160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tullivuorentie 4d",
             "postalcode": "00700"
           }
         ],
@@ -19088,7 +18180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Nallenmäenkuja 3",
             "postalcode": "00700"
           }
         ],
@@ -19109,7 +18200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kankiraudantie 6",
             "postalcode": "00700"
           }
         ],
@@ -19130,7 +18220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kankiraudantie 2a",
             "postalcode": "00700"
           }
         ],
@@ -19151,7 +18240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fastbölentie 9b",
             "postalcode": "00750"
           }
         ],
@@ -19172,7 +18260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Simonkatu 7",
             "postalcode": "00100"
           }
         ],
@@ -19193,7 +18280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkalahdentie 3",
             "postalcode": "00950"
           }
         ],
@@ -19214,7 +18300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karhulantie 7",
             "postalcode": "00950"
           }
         ],
@@ -19235,7 +18320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vehkalahdentie 36",
             "postalcode": "00950"
           }
         ],
@@ -19256,7 +18340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Linnalahdenkuja 15",
             "postalcode": "00950"
           }
         ],
@@ -19277,7 +18360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ilotulitustie 11",
             "postalcode": "00930"
           }
         ],
@@ -19298,7 +18380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniementie 60",
             "postalcode": "00930"
           }
         ],
@@ -19319,7 +18400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Stockmannintie 2",
             "postalcode": "00380"
           }
         ],
@@ -19340,7 +18420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pitäjänmäentie 22",
             "postalcode": "00380"
           }
         ],
@@ -19361,7 +18440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiomotie 6",
             "postalcode": "00380"
           }
         ],
@@ -19382,7 +18460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Hiomotie 17",
             "postalcode": "00380"
           }
         ],
@@ -19403,7 +18480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Takkatie 4",
             "postalcode": "00370"
           }
         ],
@@ -19424,7 +18500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Takkatie 3-5",
             "postalcode": "00370"
           }
         ],
@@ -19445,7 +18520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Takkatie 17",
             "postalcode": "00370"
           }
         ],
@@ -19466,7 +18540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Atomipolku 2",
             "postalcode": "00370"
           }
         ],
@@ -19487,7 +18560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Viestitie 2",
             "postalcode": "00370"
           }
         ],
@@ -19508,7 +18580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Korsutie 38",
             "postalcode": "00370"
           }
         ],
@@ -19529,7 +18600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lauritsantie 1b",
             "postalcode": "00370"
           }
         ],
@@ -19550,7 +18620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Sylvesterintie 3",
             "postalcode": "00370"
           }
         ],
@@ -19571,7 +18640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Konalantie 6",
             "postalcode": "00370"
           }
         ],
@@ -19592,7 +18660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Markunkuja 5",
             "postalcode": "00370"
           }
         ],
@@ -19613,7 +18680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Markunkuja 4",
             "postalcode": "00370"
           }
         ],
@@ -19634,7 +18700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suntionpolku 3",
             "postalcode": "00370"
           }
         ],
@@ -19655,7 +18720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lauritsantie 5",
             "postalcode": "00370"
           }
         ],
@@ -19676,7 +18740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ketokiventie 2a",
             "postalcode": "00710"
           }
         ],
@@ -19697,7 +18760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Suovaniityntie 12",
             "postalcode": "00760"
           }
         ],
@@ -19718,7 +18780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kotinummentie 16",
             "postalcode": "00700"
           }
         ],
@@ -19739,7 +18800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurkiaispolku 1",
             "postalcode": "00940"
           }
         ],
@@ -19760,7 +18820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Karpalokuja 6",
             "postalcode": "00940"
           }
         ],
@@ -19781,7 +18840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Köyliöntie 1",
             "postalcode": "00940"
           }
         ],
@@ -19802,7 +18860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kekomäentie 28",
             "postalcode": "00940"
           }
         ],
@@ -19823,7 +18880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Leväluhdantie 11b",
             "postalcode": "00940"
           }
         ],
@@ -19844,7 +18900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Jäämäentie 10",
             "postalcode": "00970"
           }
         ],
@@ -19865,7 +18920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lupajantie 3",
             "postalcode": "00970"
           }
         ],
@@ -19886,7 +18940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Ohralankuja 6",
             "postalcode": "00970"
           }
         ],
@@ -19907,7 +18960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tuhkanummentie 6",
             "postalcode": "00970"
           }
         ],
@@ -19928,7 +18980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Valtavaarankuja 4a",
             "postalcode": "00970"
           }
         ],
@@ -19949,7 +19000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kultakummuntie 4",
             "postalcode": "00940"
           }
         ],
@@ -19970,7 +19020,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mäkikurpankuja 3",
             "postalcode": "00940"
           }
         ],
@@ -19991,7 +19040,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kurkimäentie 9",
             "postalcode": "00940"
           }
         ],
@@ -20012,7 +19060,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veteraanikuja 6",
             "postalcode": "00940"
           }
         ],
@@ -20033,7 +19080,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Veteraanikuja 6",
             "postalcode": "00940"
           }
         ],
@@ -20054,7 +19100,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustikkarinne 3",
             "postalcode": "00940"
           }
         ],
@@ -20075,7 +19120,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rautapaidantie 4a",
             "postalcode": "00920"
           }
         ],
@@ -20096,7 +19140,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pikipolku 5",
             "postalcode": "00670"
           }
         ],
@@ -20117,7 +19160,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Häklinkuja 6",
             "postalcode": "00920"
           }
         ],
@@ -20138,7 +19180,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Saariselänkuja 6",
             "postalcode": "00970"
           }
         ],
@@ -20159,7 +19200,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Yllästunturintie 1",
             "postalcode": "00970"
           }
         ],
@@ -20180,7 +19220,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Savitaipaleentie 41b",
             "postalcode": "00950"
           }
         ],
@@ -20201,7 +19240,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Naulakallionkuja 7",
             "postalcode": "00970"
           }
         ],
@@ -20222,7 +19260,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Naulakalliontie 19",
             "postalcode": "00970"
           }
         ],
@@ -20243,7 +19280,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallpakankuja 5",
             "postalcode": "00970"
           }
         ],
@@ -20264,7 +19300,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallpakankuja 10",
             "postalcode": "00970"
           }
         ],
@@ -20285,7 +19320,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Fallpakankuja 10",
             "postalcode": "00970"
           }
         ],
@@ -20306,7 +19340,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Päätie 28a",
             "postalcode": "00590"
           }
         ],
@@ -20327,7 +19360,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Roihuvuorentie 1",
             "postalcode": "00820"
           }
         ],
@@ -20348,7 +19380,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Keijukaistenpolku 11",
             "postalcode": "00820"
           }
         ],
@@ -20369,7 +19400,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tulisuontie 1",
             "postalcode": "00820"
           }
         ],
@@ -20390,7 +19420,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Roihuvuorentie 17",
             "postalcode": "00820"
           }
         ],
@@ -20411,7 +19440,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Strömsinlahdenpolku 7",
             "postalcode": "00820"
           }
         ],
@@ -20432,7 +19460,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rouvienpolku 5",
             "postalcode": "00810"
           }
         ],
@@ -20453,7 +19480,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tiiliruukintie 2",
             "postalcode": "00830"
           }
         ],
@@ -20474,7 +19500,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kummeltie 9",
             "postalcode": "00830"
           }
         ],
@@ -20495,7 +19520,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tammisalontie 17a",
             "postalcode": "00830"
           }
         ],
@@ -20516,7 +19540,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Kinkeripolku 8a",
             "postalcode": "00640"
           }
         ],
@@ -20537,7 +19560,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Airotie 3",
             "postalcode": "00830"
           }
         ],
@@ -20558,7 +19580,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjalahdentie 3",
             "postalcode": "00930"
           }
         ],
@@ -20579,7 +19600,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vanamotie 13",
             "postalcode": "00930"
           }
         ],
@@ -20600,7 +19620,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniementie 42",
             "postalcode": "00930"
           }
         ],
@@ -20621,7 +19640,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Valkovuokonpolku 7",
             "postalcode": "00930"
           }
         ],
@@ -20642,7 +19660,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniementie 21",
             "postalcode": "00930"
           }
         ],
@@ -20663,7 +19680,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Marjaniementie 22",
             "postalcode": "00930"
           }
         ],
@@ -20684,7 +19700,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tattariharjuntie 4",
             "postalcode": "00700"
           }
         ],
@@ -20705,7 +19720,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Elovalkeantie 24",
             "postalcode": "00700"
           }
         ],
@@ -20726,7 +19740,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Voikukantie 5",
             "postalcode": "00930"
           }
         ],
@@ -20747,7 +19760,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Mustikkasuontie 5",
             "postalcode": "00940"
           }
         ],
@@ -20768,7 +19780,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Harakkamyllyntie 17",
             "postalcode": "00920"
           }
         ],
@@ -20789,7 +19800,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Aarteenetsijäntie 7",
             "postalcode": "00970"
           }
         ],
@@ -20810,7 +19820,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Uussillantie 21",
             "postalcode": "00950"
           }
         ],
@@ -20831,7 +19840,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Alakiventie 1",
             "postalcode": "00920"
           }
         ],
@@ -20852,7 +19860,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Vesalantie 66",
             "postalcode": "00940"
           }
         ],
@@ -20873,7 +19880,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Tinasepäntie 53",
             "postalcode": "00620"
           }
         ],
@@ -20894,7 +19900,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pulttitie 1",
             "postalcode": "00880"
           }
         ],
@@ -20915,7 +19920,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Pulttitie 15",
             "postalcode": "00880"
           }
         ],
@@ -20936,7 +19940,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Klaavuntie 15",
             "postalcode": "00910"
           }
         ],
@@ -20957,7 +19960,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Piennar 5",
             "postalcode": "00680"
           }
         ],
@@ -20978,7 +19980,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rusthollarintie 8",
             "postalcode": "00910"
           }
         ],
@@ -20999,7 +20000,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Rantakartanontie 11",
             "postalcode": "00910"
           }
         ],


### PR DESCRIPTION
Tests POI and address searches in fi and sv languages. Checks also
the name and localadmin to see that language matches the query.
Possible failures must be studied in detail, although they may not be
fatal errors. Large places like city areas may move when data changes,
causing location match failures (distance > 300 m). Also dynamic labeling
can cause name mismatches in the current setup (will be fixed in API side).

Note: test data is mainly composed of reittiopas.fi most popular searches.
