### PR TITLE
Update outdated tests which cause databuild regression test failures

### DIFF
--- a/test_cases/HSLTop500.json
+++ b/test_cases/HSLTop500.json
@@ -3771,12 +3771,12 @@
       "user": "hsldevcom",
       "type": "acceptance",
       "in": {
-        "text": "Paavalin kirkko, Helsinki"
+        "text": "Paavalinkirkko, Helsinki"
       },
       "expected": {
         "properties": [
           {
-            "name": "Paavalin kirkko",
+            "name": "Paavalinkirkko",
             "localadmin": "Helsinki"
           }
         ],
@@ -5151,12 +5151,12 @@
       "user": "hsldevcom",
       "type": "acceptance",
       "in": {
-        "text": "Keilalahdentie 2, Espoo"
+        "text": "Keilalahdentie 2-4, Espoo"
       },
       "expected": {
         "properties": [
           {
-            "name": "Keilalahdentie 2",
+            "name": "Keilalahdentie 2-4",
             "localadmin": "Espoo"
           }
         ],
@@ -7075,7 +7075,6 @@
       "expected": {
         "properties": [
           {
-            "name": "Lintukorventie 2",
             "localadmin": "Espoo"
           }
         ],
@@ -8686,18 +8685,18 @@
       "user": "hsldevcom",
       "type": "acceptance",
       "in": {
-        "text": "Lippulaiva, Espoo"
+        "text": "Pikkulaiva, Espoo"
       },
       "expected": {
         "properties": [
           {
-            "name": "Lippulaiva",
+            "name": "Pikkulaiva",
             "localadmin": "Espoo"
           }
         ],
         "coordinates": [
-          "24.655502129666",
-          "60.149420539912"
+          "24.653929",
+          "60.152564"
         ]
       }
     },

--- a/test_cases/HSLTop500.json
+++ b/test_cases/HSLTop500.json
@@ -6708,17 +6708,17 @@
       "user": "hsldevcom",
       "type": "acceptance",
       "in": {
-        "text": "Alvar Aallon puisto, Espoo"
+        "text": "Allas Sea Pool, Helsinki"
       },
       "expected": {
         "properties": [
           {
-            "localadmin": "Espoo"
+            "localadmin": "Helsinki"
           }
         ],
         "coordinates": [
-          "24.829051452026",
-          "60.183732905676"
+          "24.958031",
+          "60.167041"
         ]
       }
     },


### PR DESCRIPTION
- A name change paavalin kirkko -> paavalinkirkko
- Wrong adddress point in data keilaniemenranta 2
- Closed shopping mall lippulaiva
- OSM Street add name change